### PR TITLE
feat(entra): support AdministrativeUnit membership via entitlements

### DIFF
--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -11,16 +11,16 @@ import EntraLeaver from '@site/../examples/workflows/templates/entraid-leaver.ps
 ## Summary
 
 - **Module:** `IdLE.Provider.EntraID`
-- **What it’s for:** Entra ID user lifecycle + group entitlements (Microsoft Graph API)
+- **What it’s for:** Entra ID user lifecycle + group and Administrative Unit entitlements (Microsoft Graph API)
 - **Targets:** Microsoft Entra ID (formerly Azure AD) via Microsoft Graph (v1.0)
 
 ## When to use
 
 Use this provider when your workflow needs to manage **Entra ID user accounts**, for example:
 
-- **Joiner:** create or update a user, set baseline attributes, assign baseline groups
+- **Joiner:** create or update a user, set baseline attributes, assign baseline groups and Administrative Units
 - **Mover:** update org attributes and managed groups (covered as *optional patterns* inside the Joiner template)
-- **Leaver:** disable account, revoke sessions, optional cleanup (groups, delete)
+- **Leaver:** disable account, revoke sessions, optional cleanup (groups, Administrative Units, delete)
 
 Non-goals:
 
@@ -32,7 +32,7 @@ Non-goals:
 ### Requirements
 
 - Your runtime must be able to supply a **Microsoft Graph auth session** (token/session object) to IdLE
-- Graph permissions must allow the actions you intend to run (users + groups)
+- Graph permissions must allow the actions you intend to run (users, groups, Administrative Units)
 
 ### Install (PowerShell Gallery)
 
@@ -127,20 +127,88 @@ Writes to scoped path: `Request.Context.Providers.<ProviderAlias>.<AuthSessionKe
 Engine-defined View: `Request.Context.Views.Identity.Entitlements`  
 Type: `object[]` (array of `PSCustomObject`, `PSTypeName = 'IdLE.Entitlement'`)
 
-Each element represents one Entra ID group membership:
+Each element represents one entitlement (group membership or Administrative Unit membership):
+
+**Group entitlements (`Kind = 'Group'`):**
 
 | Property | Type | Notes |
 | --- | --- | --- |
 | `PSTypeName` | `string` | Always `IdLE.Entitlement`. |
 | `Kind` | `string` | Always `Group`. |
-| `Id` | `string` | Entra group `id`. |
-| `Mail` | `string` or `$null` | Group `mail` (if returned by the adapter). |
+| `Id` | `string` | Entra group object ID (GUID). |
+| `Mail` | `string` or `$null` | Group `mail` (if returned by Graph). |
+
+**Administrative Unit entitlements (`Kind = 'AdministrativeUnit'`):**
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `PSTypeName` | `string` | Always `IdLE.Entitlement`. |
+| `Kind` | `string` | Always `AdministrativeUnit`. |
+| `Id` | `string` | Entra Administrative Unit object ID (GUID). |
 
 Notes:
 - The output paths are fixed by the engine and cannot be changed.
 - Each entry is automatically annotated with `SourceProvider` and `SourceAuthSessionName` metadata.
 - Use the global View (`Request.Context.Views.Identity.Entitlements`) in **Conditions** when you don't need to filter by provider. Use the scoped path when you need results from a specific provider only.
 - See [Context Resolvers](../../use/workflows/context-resolver.md) for the full path reference.
+
+## Administrative Unit entitlements
+
+Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitlements. They control which scoped admins can manage which users — assigning a user to an AU makes them visible to that AU's scoped admin roles.
+
+### Supported operations
+
+| Operation | Behaviour |
+| --- | --- |
+| `ListEntitlements` | Returns all current AU memberships alongside group memberships. |
+| `GrantEntitlement` | Adds the user to the specified AU. Idempotent — no error if already a member. |
+| `RevokeEntitlement` | Removes the user from the specified AU. Idempotent — no error if not a member. |
+| `PruneEntitlements` | Covered automatically: `ListEntitlements` returns both groups and AUs, so the Prune step removes unlisted AUs in the same pass as groups. |
+
+### Workflow usage
+
+```powershell
+# Ensure a user is assigned to an Administrative Unit (Joiner / Mover)
+@{
+    Name = 'Assign to HR Administrative Unit'
+    Type = 'IdLE.Step.EnsureEntitlement'
+    With = @{
+        IdentityKey     = '{{Request.IdentityKeys.Id}}'
+        Provider        = 'Entra'
+        AuthSessionName = 'MicrosoftGraph'
+        Entitlement     = @{ Kind = 'AdministrativeUnit'; Id = '<AU-ObjectId-GUID>' }
+        State           = 'Present'
+    }
+}
+
+# Remove a user from an Administrative Unit (Leaver / Mover)
+@{
+    Name = 'Remove from HR Administrative Unit'
+    Type = 'IdLE.Step.EnsureEntitlement'
+    With = @{
+        IdentityKey     = '{{Request.IdentityKeys.Id}}'
+        Provider        = 'Entra'
+        AuthSessionName = 'MicrosoftGraph'
+        Entitlement     = @{ Kind = 'AdministrativeUnit'; Id = '<AU-ObjectId-GUID>' }
+        State           = 'Absent'
+    }
+}
+```
+
+### Constraints
+
+- Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU ID is not found.
+- AUs are referenced **only by their object ID (GUID)** — display-name lookup is not supported, as AU names are not guaranteed to be unique within a tenant.
+- Bulk operations (`BulkGrantEntitlements` / `BulkRevokeEntitlements`) are Group-only and do not support `Kind = 'AdministrativeUnit'`. Use individual `GrantEntitlement` / `RevokeEntitlement` calls for AU membership changes.
+
+### Graph endpoints used
+
+| Operation | Endpoint |
+| --- | --- |
+| List | `GET /users/{id}/memberOf/microsoft.graph.administrativeUnit` |
+| Grant | `POST /administrativeUnits/{id}/members/$ref` |
+| Revoke | `DELETE /administrativeUnits/{id}/members/{userId}/$ref` |
+| Validate AU exists | `GET /administrativeUnits/{id}` |
 
 ## Configuration
 
@@ -159,9 +227,19 @@ This provider has **no provider-specific option bag**. Configuration is done thr
 
 At minimum, you typically need:
 - **Users:** read/write (create/update/disable/delete if enabled)
-- **Groups:** read/write memberships (if you use entitlement steps)
+- **Groups:** read/write memberships (if you use group entitlement steps)
+- **Administrative Units:** read/write memberships (if you use Administrative Unit entitlement steps)
 
 Exact permission names depend on your auth model (delegated vs application) and what operations you enable.
+
+| Capability | Permission (Application) |
+| --- | --- |
+| List/Read users | `User.Read.All` |
+| Create/update/disable users | `User.ReadWrite.All` |
+| List group memberships | `Group.Read.All` |
+| Grant/revoke group memberships | `GroupMember.ReadWrite.All` |
+| List AU memberships | `AdministrativeUnit.Read.All` |
+| Grant/revoke AU memberships | `AdministrativeUnit.ReadWrite.All` |
 
 ## Examples (canonical templates)
 
@@ -178,3 +256,4 @@ Mover scenarios are integrated as **optional patterns** in the Joiner template.
 - **Auth session not found**: check `AuthSessionName` matches your runtime/broker configuration.
 - **Delete doesn’t work**: deletion is opt-in. Create the provider with `-AllowDelete` and only use delete with a privileged auth role.
 - **Group cleanup is disruptive**: only enable revoke/remove operations when you fully understand the impact (prefer managed allow-lists).
+- **Administrative Unit not found**: the AU object ID must exist in Entra before the workflow runs. The provider throws a descriptive error if the AU is not found — check the GUID and ensure `AdministrativeUnit.Read.All` permission is granted.

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -199,7 +199,8 @@ Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitle
 
 - Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU is not found.
 - AUs can be referenced by **object ID (GUID)** or by **displayName**. Display-name lookup is supported for convenience, but AU display names are not guaranteed to be unique within a tenant — if multiple AUs share the same name, the provider throws an error and requires the object ID to be used instead.
-- Bulk operations (`BulkGrantEntitlements` / `BulkRevokeEntitlements`) are Group-only and do not support `Kind = 'AdministrativeUnit'`. Use individual `GrantEntitlement` / `RevokeEntitlement` calls for AU membership changes.
+- `BulkGrantEntitlements` is Group-only and does not support `Kind = 'AdministrativeUnit'` (the Graph batch API uses group-specific URLs). Use individual `GrantEntitlement` calls for AU membership changes.
+- `BulkRevokeEntitlements` supports both `Kind = 'Group'` (batch path) and `Kind = 'AdministrativeUnit'` (per-item path, no batch API exists for AUs). Mixed-kind batches are accepted.
 
 ### Graph endpoints used
 

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -197,8 +197,8 @@ Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitle
 
 ### Constraints
 
-- Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU ID is not found.
-- AUs are referenced **only by their object ID (GUID)** — display-name lookup is not supported, as AU names are not guaranteed to be unique within a tenant.
+- Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU is not found.
+- AUs can be referenced by **object ID (GUID)** or by **displayName**. Display-name lookup is supported for convenience, but AU display names are not guaranteed to be unique within a tenant — if multiple AUs share the same name, the provider throws an error and requires the object ID to be used instead.
 - Bulk operations (`BulkGrantEntitlements` / `BulkRevokeEntitlements`) are Group-only and do not support `Kind = 'AdministrativeUnit'`. Use individual `GrantEntitlement` / `RevokeEntitlement` calls for AU membership changes.
 
 ### Graph endpoints used
@@ -208,7 +208,8 @@ Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitle
 | List | `GET /users/{id}/memberOf/microsoft.graph.administrativeUnit` |
 | Grant | `POST /directory/administrativeUnits/{id}/members/$ref` |
 | Revoke | `DELETE /directory/administrativeUnits/{id}/members/{userId}/$ref` |
-| Validate AU exists | `GET /directory/administrativeUnits/{id}` |
+| Validate AU exists by ID | `GET /directory/administrativeUnits/{id}` |
+| Resolve AU by displayName | `GET /directory/administrativeUnits?$filter=displayName eq '...'` |
 
 ## Configuration
 
@@ -256,4 +257,5 @@ Mover scenarios are integrated as **optional patterns** in the Joiner template.
 - **Auth session not found**: check `AuthSessionName` matches your runtime/broker configuration.
 - **Delete doesn’t work**: deletion is opt-in. Create the provider with `-AllowDelete` and only use delete with a privileged auth role.
 - **Group cleanup is disruptive**: only enable revoke/remove operations when you fully understand the impact (prefer managed allow-lists).
-- **Administrative Unit not found**: the AU object ID must exist in Entra before the workflow runs. The provider throws a descriptive error if the AU is not found — check the GUID and ensure `AdministrativeUnit.Read.All` permission is granted.
+- **Administrative Unit not found**: the AU must exist in Entra before the workflow runs. When referencing by objectId, confirm the GUID is correct. When referencing by displayName, confirm the name matches exactly and `AdministrativeUnit.Read.All` permission is granted.
+- **Multiple AUs match displayName**: AU display names are not unique in Entra. If multiple AUs share the same name, use the objectId (GUID) instead to ensure deterministic lookup.

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -199,8 +199,7 @@ Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitle
 
 - Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU is not found.
 - AUs can be referenced by **object ID (GUID)** or by **displayName**. Display-name lookup is supported for convenience, but AU display names are not guaranteed to be unique within a tenant — if multiple AUs share the same name, the provider throws an error and requires the object ID to be used instead.
-- `BulkGrantEntitlements` is Group-only and does not support `Kind = 'AdministrativeUnit'` (the Graph batch API uses group-specific URLs). Use individual `GrantEntitlement` calls for AU membership changes.
-- `BulkRevokeEntitlements` supports both `Kind = 'Group'` (batch path) and `Kind = 'AdministrativeUnit'` (per-item path, no batch API exists for AUs). Mixed-kind batches are accepted.
+- `BulkGrantEntitlements` and `BulkRevokeEntitlements` both support `Kind = 'Group'` (Graph batch path) and `Kind = 'AdministrativeUnit'` (per-item path — no Graph batch API exists for AU membership changes). Mixed-kind batches are accepted in both methods. This ensures `PruneEntitlementsEnsureKeep` works correctly for AUs (it calls both bulk methods internally).
 
 ### Graph endpoints used
 

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -168,7 +168,7 @@ This provider has **no provider-specific option bag**. Configuration is done thr
 At minimum, you typically need:
 - **Users:** read/write (create/update/disable/delete if enabled)
 - **Groups:** read/write memberships (if you use group entitlement steps)
-- **Administrative Units:** read/write memberships (if you use Administrative Unit entitlement steps)
+- **Administrative Units:** read/write memberships — only required when using `Kind = 'AdministrativeUnit'` in entitlement steps. Group-only workflows do not need these permissions because `ListEntitlements` skips AU Graph calls when `Kind = 'Group'` is specified.
 
 Exact permission names depend on your auth model (delegated vs application) and what operations you enable.
 
@@ -178,8 +178,8 @@ Exact permission names depend on your auth model (delegated vs application) and 
 | Create/update/disable users | `User.ReadWrite.All` |
 | List group memberships | `Group.Read.All` |
 | Grant/revoke group memberships | `GroupMember.ReadWrite.All` |
-| List AU memberships | `AdministrativeUnit.Read.All` |
-| Grant/revoke AU memberships | `AdministrativeUnit.ReadWrite.All` |
+| List AU memberships (`Kind = 'AdministrativeUnit'`) | `AdministrativeUnit.Read.All` |
+| Grant/revoke AU memberships (`Kind = 'AdministrativeUnit'`) | `AdministrativeUnit.ReadWrite.All` |
 
 ## Examples (canonical templates)
 

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -133,7 +133,6 @@ Each element represents one entitlement (group membership or Administrative Unit
 
 | Property | Type | Notes |
 | --- | --- | --- |
-| `PSTypeName` | `string` | Always `IdLE.Entitlement`. |
 | `Kind` | `string` | Always `Group`. |
 | `Id` | `string` | Entra group object ID (GUID). |
 | `Mail` | `string` or `$null` | Group `mail` (if returned by Graph). |
@@ -142,7 +141,6 @@ Each element represents one entitlement (group membership or Administrative Unit
 
 | Property | Type | Notes |
 | --- | --- | --- |
-| `PSTypeName` | `string` | Always `IdLE.Entitlement`. |
 | `Kind` | `string` | Always `AdministrativeUnit`. |
 | `Id` | `string` | Entra Administrative Unit object ID (GUID). |
 
@@ -151,65 +149,6 @@ Notes:
 - Each entry is automatically annotated with `SourceProvider` and `SourceAuthSessionName` metadata.
 - Use the global View (`Request.Context.Views.Identity.Entitlements`) in **Conditions** when you don't need to filter by provider. Use the scoped path when you need results from a specific provider only.
 - See [Context Resolvers](../../use/workflows/context-resolver.md) for the full path reference.
-
-## Administrative Unit entitlements
-
-Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitlements. They control which scoped admins can manage which users — assigning a user to an AU makes them visible to that AU's scoped admin roles.
-
-### Supported operations
-
-| Operation | Behaviour |
-| --- | --- |
-| `ListEntitlements` | Returns all current AU memberships alongside group memberships. |
-| `GrantEntitlement` | Adds the user to the specified AU. Idempotent — no error if already a member. |
-| `RevokeEntitlement` | Removes the user from the specified AU. Idempotent — no error if not a member. |
-| `PruneEntitlements` | Covered automatically: `ListEntitlements` returns both groups and AUs, so the Prune step removes unlisted AUs in the same pass as groups. |
-
-### Workflow usage
-
-```powershell
-# Ensure a user is assigned to an Administrative Unit (Joiner / Mover)
-@{
-    Name = 'Assign to HR Administrative Unit'
-    Type = 'IdLE.Step.EnsureEntitlement'
-    With = @{
-        IdentityKey     = '{{Request.IdentityKeys.Id}}'
-        Provider        = 'Entra'
-        AuthSessionName = 'MicrosoftGraph'
-        Entitlement     = @{ Kind = 'AdministrativeUnit'; Id = '<AU-ObjectId-GUID>' }
-        State           = 'Present'
-    }
-}
-
-# Remove a user from an Administrative Unit (Leaver / Mover)
-@{
-    Name = 'Remove from HR Administrative Unit'
-    Type = 'IdLE.Step.EnsureEntitlement'
-    With = @{
-        IdentityKey     = '{{Request.IdentityKeys.Id}}'
-        Provider        = 'Entra'
-        AuthSessionName = 'MicrosoftGraph'
-        Entitlement     = @{ Kind = 'AdministrativeUnit'; Id = '<AU-ObjectId-GUID>' }
-        State           = 'Absent'
-    }
-}
-```
-
-### Constraints
-
-- Administrative Units must be **pre-created in Entra** before being referenced in a workflow. The provider validates AU existence and throws a clear, actionable error if the AU is not found.
-- AUs can be referenced by **object ID (GUID)** or by **displayName**. Display-name lookup is supported for convenience, but AU display names are not guaranteed to be unique within a tenant — if multiple AUs share the same name, the provider throws an error and requires the object ID to be used instead.
-- `BulkGrantEntitlements` and `BulkRevokeEntitlements` both support `Kind = 'Group'` (Graph batch path) and `Kind = 'AdministrativeUnit'` (per-item path — no Graph batch API exists for AU membership changes). Mixed-kind batches are accepted in both methods. This ensures `PruneEntitlementsEnsureKeep` works correctly for AUs (it calls both bulk methods internally).
-
-### Graph endpoints used
-
-| Operation | Endpoint |
-| --- | --- |
-| List | `GET /users/{id}/memberOf/microsoft.graph.administrativeUnit` |
-| Grant | `POST /directory/administrativeUnits/{id}/members/$ref` |
-| Revoke | `DELETE /directory/administrativeUnits/{id}/members/{userId}/$ref` |
-| Validate AU exists by ID | `GET /directory/administrativeUnits/{id}` |
-| Resolve AU by displayName | `GET /directory/administrativeUnits?$filter=displayName eq '...'` |
 
 ## Configuration
 

--- a/docs/reference/providers/provider-entraID.md
+++ b/docs/reference/providers/provider-entraID.md
@@ -206,9 +206,9 @@ Administrative Units (AUs) are modelled as `Kind = 'AdministrativeUnit'` entitle
 | Operation | Endpoint |
 | --- | --- |
 | List | `GET /users/{id}/memberOf/microsoft.graph.administrativeUnit` |
-| Grant | `POST /administrativeUnits/{id}/members/$ref` |
-| Revoke | `DELETE /administrativeUnits/{id}/members/{userId}/$ref` |
-| Validate AU exists | `GET /administrativeUnits/{id}` |
+| Grant | `POST /directory/administrativeUnits/{id}/members/$ref` |
+| Revoke | `DELETE /directory/administrativeUnits/{id}/members/{userId}/$ref` |
+| Validate AU exists | `GET /directory/administrativeUnits/{id}` |
 
 ## Configuration
 

--- a/examples/workflows/templates/entraid-joiner.psd1
+++ b/examples/workflows/templates/entraid-joiner.psd1
@@ -1,7 +1,7 @@
 @{
     Name           = 'EntraID Joiner - Complete Onboarding'
     LifecycleEvent = 'Joiner'
-    Description    = 'Creates or updates an Entra ID user with baseline attributes and group memberships. Includes optional mover patterns.'
+    Description    = 'Creates or updates an Entra ID user with baseline attributes, group memberships, and Administrative Unit assignments. Includes optional mover patterns.'
 
     Steps          = @(
         @{
@@ -10,9 +10,8 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                
-                # Using UPN keeps it human-friendly in templates.
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
 
                 Attributes         = @{
                     UserPrincipalName = '{{Request.Intent.UserPrincipalName}}'
@@ -37,49 +36,53 @@
             }
         }
 
+        # Baseline groups: add one EnsureEntitlement step per group.
         @{
-            Name = 'AddToBaselineGroups'
+            Name = 'AddToAllEmployeesGroup'
             Type = 'IdLE.Step.EnsureEntitlement'
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-
-                # Using UPN keeps it human-friendly in templates.
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
-
-                # Baseline groups should be explicit and driven by request input (no hardcoding).
-                Desired            = @(
-                    @{
-                        Kind        = 'Group'
-                        Id          = '{{Request.Intent.AllEmployeesGroupId}}'
-                        DisplayName = '{{Request.Intent.AllEmployeesGroupName}}'
-                    }
-                    @{
-                        Kind        = 'Group'
-                        Id          = '{{Request.Intent.DepartmentGroupId}}'
-                        DisplayName = '{{Request.Intent.DepartmentGroupName}}'
-                    }
-                )
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind        = 'Group'
+                    Id          = '{{Request.Intent.AllEmployeesGroupId}}'
+                    DisplayName = '{{Request.Intent.AllEmployeesGroupName}}'
+                }
+                State              = 'Present'
             }
         }
 
         @{
-            Name = 'AddToBaselineAdministrativeUnits'
+            Name = 'AddToDepartmentGroup'
             Type = 'IdLE.Step.EnsureEntitlement'
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind        = 'Group'
+                    Id          = '{{Request.Intent.DepartmentGroupId}}'
+                    DisplayName = '{{Request.Intent.DepartmentGroupName}}'
+                }
+                State              = 'Present'
+            }
+        }
 
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
-
-                # Baseline Administrative Units control which scoped admins can manage this user.
-                # Reference AUs by their Entra object ID (GUID). AUs must exist in Entra before use.
-                Desired            = @(
-                    @{
-                        Kind = 'AdministrativeUnit'
-                        Id   = '{{Request.Intent.DepartmentAdministrativeUnitId}}'
-                    }
-                )
+        # Baseline Administrative Unit: controls which scoped admins can manage this user.
+        # AUs can be referenced by their GUID objectId or by displayName (tenant-unique names only).
+        @{
+            Name = 'AddToDepartmentAdministrativeUnit'
+            Type = 'IdLE.Step.EnsureEntitlement'
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind = 'AdministrativeUnit'
+                    Id   = '{{Request.Intent.DepartmentAdministrativeUnitId}}'
+                }
+                State              = 'Present'
             }
         }
 
@@ -89,7 +92,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
             }
         }
 
@@ -115,19 +118,20 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
 
                 Attributes         = @{
                     Department     = '{{Request.Intent.NewDepartment}}'
-                    JobTitle        = '{{Request.Intent.NewJobTitle}}'
-                    OfficeLocation  = '{{Request.Intent.NewOfficeLocation}}'
-                    Manager         = '{{Request.Intent.NewManagerObjectId}}'
+                    JobTitle       = '{{Request.Intent.NewJobTitle}}'
+                    OfficeLocation = '{{Request.Intent.NewOfficeLocation}}'
+                    Manager        = '{{Request.Intent.NewManagerObjectId}}'
                 }
             }
         }
 
+        # Add one EnsureEntitlement step per group change required on a mover.
         @{
-            Name      = 'Mover_AdjustManagedGroups'
+            Name      = 'Mover_AddToDepartmentGroup'
             Type      = 'IdLE.Step.EnsureEntitlement'
             Condition = @{
                 All = @(
@@ -142,26 +146,18 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
-
-                # Optional: add department/project groups as part of a move.
-                Desired            = @(
-                    @{
-                        Kind        = 'Group'
-                        Id          = '{{Request.Intent.DepartmentGroupId}}'
-                        DisplayName = '{{Request.Intent.DepartmentGroupName}}'
-                    }
-                    @{
-                        Kind        = 'Group'
-                        Id          = '{{Request.Intent.ProjectGroupId}}'
-                        DisplayName = '{{Request.Intent.ProjectGroupName}}'
-                    }
-                )
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind        = 'Group'
+                    Id          = '{{Request.Intent.DepartmentGroupId}}'
+                    DisplayName = '{{Request.Intent.DepartmentGroupName}}'
+                }
+                State              = 'Present'
             }
         }
 
         @{
-            Name      = 'Mover_AdjustAdministrativeUnitMemberships'
+            Name      = 'Mover_AddToProjectGroup'
             Type      = 'IdLE.Step.EnsureEntitlement'
             Condition = @{
                 All = @(
@@ -176,16 +172,39 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind        = 'Group'
+                    Id          = '{{Request.Intent.ProjectGroupId}}'
+                    DisplayName = '{{Request.Intent.ProjectGroupName}}'
+                }
+                State              = 'Present'
+            }
+        }
 
-                # Reassign to the new department's Administrative Unit on a move.
-                # AUs are referenced by Entra object ID (GUID) and must exist before use.
-                Desired            = @(
+        # Reassign to the new department's Administrative Unit on a move.
+        @{
+            Name      = 'Mover_AddToNewDepartmentAdministrativeUnit'
+            Type      = 'IdLE.Step.EnsureEntitlement'
+            Condition = @{
+                All = @(
                     @{
-                        Kind = 'AdministrativeUnit'
-                        Id   = '{{Request.Intent.NewDepartmentAdministrativeUnitId}}'
+                        Equals = @{
+                            Path  = 'Request.Intent.IsMover'
+                            Value = $true
+                        }
                     }
                 )
+            }
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Entitlement        = @{
+                    Kind = 'AdministrativeUnit'
+                    Id   = '{{Request.Intent.NewDepartmentAdministrativeUnitId}}'
+                }
+                State              = 'Present'
             }
         }
 
@@ -193,7 +212,7 @@
             Name = 'EmitCompletionEvent'
             Type = 'IdLE.Step.EmitEvent'
             With = @{
-                Message = 'EntraID user {{Request.Intent.UserPrincipalName}} created/updated successfully.'
+                Message = 'EntraID user {{Request.IdentityKeys.UserPrincipalName}} created/updated successfully.'
             }
         }
     )

--- a/examples/workflows/templates/entraid-joiner.psd1
+++ b/examples/workflows/templates/entraid-joiner.psd1
@@ -45,9 +45,8 @@
                 AuthSessionOptions = @{ Role = 'Admin' }
                 IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Entitlement        = @{
-                    Kind        = 'Group'
-                    Id          = '{{Request.Intent.AllEmployeesGroupId}}'
-                    DisplayName = '{{Request.Intent.AllEmployeesGroupName}}'
+                    Kind = 'Group'
+                    Id   = '{{Request.Intent.AllEmployeesGroupId}}'
                 }
                 State              = 'Present'
             }
@@ -61,9 +60,8 @@
                 AuthSessionOptions = @{ Role = 'Admin' }
                 IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Entitlement        = @{
-                    Kind        = 'Group'
-                    Id          = '{{Request.Intent.DepartmentGroupId}}'
-                    DisplayName = '{{Request.Intent.DepartmentGroupName}}'
+                    Kind = 'Group'
+                    Id   = '{{Request.Intent.DepartmentGroupId}}'
                 }
                 State              = 'Present'
             }
@@ -148,9 +146,8 @@
                 AuthSessionOptions = @{ Role = 'Admin' }
                 IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Entitlement        = @{
-                    Kind        = 'Group'
-                    Id          = '{{Request.Intent.DepartmentGroupId}}'
-                    DisplayName = '{{Request.Intent.DepartmentGroupName}}'
+                    Kind = 'Group'
+                    Id   = '{{Request.Intent.DepartmentGroupId}}'
                 }
                 State              = 'Present'
             }
@@ -174,9 +171,8 @@
                 AuthSessionOptions = @{ Role = 'Admin' }
                 IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Entitlement        = @{
-                    Kind        = 'Group'
-                    Id          = '{{Request.Intent.ProjectGroupId}}'
-                    DisplayName = '{{Request.Intent.ProjectGroupName}}'
+                    Kind = 'Group'
+                    Id   = '{{Request.Intent.ProjectGroupId}}'
                 }
                 State              = 'Present'
             }

--- a/examples/workflows/templates/entraid-joiner.psd1
+++ b/examples/workflows/templates/entraid-joiner.psd1
@@ -64,6 +64,26 @@
         }
 
         @{
+            Name = 'AddToBaselineAdministrativeUnits'
+            Type = 'IdLE.Step.EnsureEntitlement'
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+
+                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+
+                # Baseline Administrative Units control which scoped admins can manage this user.
+                # Reference AUs by their Entra object ID (GUID). AUs must exist in Entra before use.
+                Desired            = @(
+                    @{
+                        Kind = 'AdministrativeUnit'
+                        Id   = '{{Request.Intent.DepartmentAdministrativeUnitId}}'
+                    }
+                )
+            }
+        }
+
+        @{
             Name = 'EnableAccount'
             Type = 'IdLE.Step.EnableIdentity'
             With = @{
@@ -135,6 +155,35 @@
                         Kind        = 'Group'
                         Id          = '{{Request.Intent.ProjectGroupId}}'
                         DisplayName = '{{Request.Intent.ProjectGroupName}}'
+                    }
+                )
+            }
+        }
+
+        @{
+            Name      = 'Mover_AdjustAdministrativeUnitMemberships'
+            Type      = 'IdLE.Step.EnsureEntitlement'
+            Condition = @{
+                All = @(
+                    @{
+                        Equals = @{
+                            Path  = 'Request.Intent.IsMover'
+                            Value = $true
+                        }
+                    }
+                )
+            }
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+
+                # Reassign to the new department's Administrative Unit on a move.
+                # AUs are referenced by Entra object ID (GUID) and must exist before use.
+                Desired            = @(
+                    @{
+                        Kind = 'AdministrativeUnit'
+                        Id   = '{{Request.Intent.NewDepartmentAdministrativeUnitId}}'
                     }
                 )
             }

--- a/examples/workflows/templates/entraid-leaver.psd1
+++ b/examples/workflows/templates/entraid-leaver.psd1
@@ -99,6 +99,31 @@
             }
         }
 
+        # Optional: remove the user from all Administrative Units.
+        # Use when scoped admin visibility must be revoked as part of offboarding.
+        @{
+            Name      = 'RevokeAdministrativeUnitMemberships_Optional'
+            Type      = 'IdLE.Step.PruneEntitlements'
+            Condition = @{
+                All = @(
+                    @{
+                        Equals = @{
+                            Path  = 'Request.Intent.RevokeAdministrativeUnitMemberships'
+                            Value = $true
+                        }
+                    }
+                )
+            }
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                Kind               = 'AdministrativeUnit'
+                # Keep = @() means remove all AU memberships.
+                Keep               = @()
+            }
+        }
+
         # Optional delete (requires provider to be created with -AllowDelete)
         @{
             Name      = 'DeleteAccount_Optional'

--- a/examples/workflows/templates/entraid-leaver.psd1
+++ b/examples/workflows/templates/entraid-leaver.psd1
@@ -10,9 +10,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-
-                # Prefer ObjectId for leaver (stable), but you may also use UPN if your provider supports it.
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
             }
         }
 
@@ -22,7 +20,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
             }
         }
 
@@ -32,7 +30,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Attributes         = @{
                     DisplayName = '{{Request.Intent.DisplayName}} (LEAVER)'
                     Manager     = $null
@@ -40,11 +38,11 @@
             }
         }
 
-        # Optional & potentially disruptive:
-        # Setting Desired = @() will remove *all* group memberships the provider manages.
+        # Optional: remove ALL group memberships — use when no specific groups need to be retained.
+        # PruneEntitlements with an empty Keep list removes every group the provider sees.
         @{
             Name      = 'RevokeAllGroupMemberships_Optional'
-            Type      = 'IdLE.Step.EnsureEntitlement'
+            Type      = 'IdLE.Step.PruneEntitlements'
             Condition = @{
                 All = @(
                     @{
@@ -58,18 +56,15 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
-                Entitlement        = @{
-                    Kind = 'Group';
-                    Id = '*'
-                }
-                State = 'Absent'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Kind               = 'Group'
+                Keep               = @()
             }
         }
 
-        # Optional & potentially disruptive:
+        # Optional: remove all groups EXCEPT a retain set AND ensure retain set is present.
         # PruneEntitlementsEnsureKeep removes all groups except the keep set AND ensures
-        # explicit Keep items are present. Use PruneEntitlements if you only need removal.
+        # explicit Keep items are present. Use PruneEntitlements (above) if you only need removal.
         @{
             Name      = 'PruneGroupMemberships_Optional'
             Type      = 'IdLE.Step.PruneEntitlementsEnsureKeep'
@@ -86,7 +81,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Kind               = 'Group'
 
                 # Retain this specific leaver group and ensure it is present.
@@ -117,9 +112,8 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Admin' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Kind               = 'AdministrativeUnit'
-                # Keep = @() means remove all AU memberships.
                 Keep               = @()
             }
         }
@@ -141,7 +135,7 @@
             With = @{
                 AuthSessionName    = 'MicrosoftGraph'
                 AuthSessionOptions = @{ Role = 'Tier0' }
-                IdentityKey        = '{{Request.Intent.UserPrincipalName}}'
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
             }
         }
 
@@ -149,8 +143,9 @@
             Name = 'EmitCompletionEvent'
             Type = 'IdLE.Step.EmitEvent'
             With = @{
-                Message = 'EntraID user {{Request.Intent.UserPrincipalName}} offboarding completed.'
+                Message = 'EntraID user {{Request.IdentityKeys.UserPrincipalName}} offboarding completed.'
             }
         }
     )
 }
+

--- a/examples/workflows/templates/entraid-leaver.psd1
+++ b/examples/workflows/templates/entraid-leaver.psd1
@@ -96,6 +96,10 @@
 
         # Optional: remove the user from all Administrative Units.
         # Use when scoped admin visibility must be revoked as part of offboarding.
+        # This is remove-only: no AU is added. Existing memberships NOT in Keep are removed;
+        # Keep entries are protected but NOT granted if missing.
+        # Use PruneAdministrativeUnitMemberships_Optional (below) when you also need to guarantee
+        # a specific AU is present after the prune.
         @{
             Name      = 'RevokeAdministrativeUnitMemberships_Optional'
             Type      = 'IdLE.Step.PruneEntitlements'
@@ -115,6 +119,37 @@
                 IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
                 Kind               = 'AdministrativeUnit'
                 Keep               = @()
+            }
+        }
+
+        # Optional: remove all AU memberships EXCEPT a retain set AND ensure retain set is present.
+        # PruneEntitlementsEnsureKeep removes all AU memberships except the keep set AND grants
+        # any Keep AU that is not currently assigned.
+        # Use PruneEntitlements (above) if you only need removal with no guaranteed grant.
+        @{
+            Name      = 'PruneAdministrativeUnitMemberships_Optional'
+            Type      = 'IdLE.Step.PruneEntitlementsEnsureKeep'
+            Condition = @{
+                All = @(
+                    @{
+                        Equals = @{
+                            Path  = 'Request.Intent.PruneAdministrativeUnitMemberships'
+                            Value = $true
+                        }
+                    }
+                )
+            }
+            With = @{
+                AuthSessionName    = 'MicrosoftGraph'
+                AuthSessionOptions = @{ Role = 'Admin' }
+                IdentityKey        = '{{Request.IdentityKeys.UserPrincipalName}}'
+                Kind               = 'AdministrativeUnit'
+
+                # This AU is retained AND guaranteed to be present after the step.
+                # Reference by objectId (GUID) or by displayName (must be tenant-unique).
+                Keep               = @(
+                    @{ Kind = 'AdministrativeUnit'; Id = '{{Request.Intent.RetainAdministrativeUnitId}}' }
+                )
             }
         }
 

--- a/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
+++ b/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
@@ -347,7 +347,9 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $encodedName = [System.Net.WebUtility]::UrlEncode($DisplayName)
+        # Escape single quotes for OData string literals (doubling), then URL-encode for the URI
+        $odataEscapedName = $DisplayName.Replace("'", "''")
+        $encodedName = [System.Net.WebUtility]::UrlEncode($odataEscapedName)
         $uri = "$($this.BaseUri)/groups?`$filter=displayName eq '$encodedName'"
         $uri += '&$select=id,displayName,mail,mailNickname'
 
@@ -419,7 +421,9 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $encodedName = [System.Net.WebUtility]::UrlEncode($DisplayName)
+        # Escape single quotes for OData string literals (doubling), then URL-encode for the URI
+        $odataEscapedName = $DisplayName.Replace("'", "''")
+        $encodedName = [System.Net.WebUtility]::UrlEncode($odataEscapedName)
         $uri = "$($this.BaseUri)/directory/administrativeUnits?`$filter=displayName eq '$encodedName'"
         $uri += '&$select=id,displayName'
 

--- a/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
+++ b/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
@@ -372,11 +372,116 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $uri = "$($this.BaseUri)/users/$ObjectId/memberOf"
+        $uri = "$($this.BaseUri)/users/$ObjectId/memberOf/microsoft.graph.group"
         $uri += '?$select=id,displayName,mail'
 
         $groups = $this.GetAllPages($uri, $AccessToken)
         return $groups
+    } -Force
+
+    $adapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AuId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AccessToken
+        )
+
+        $uri = "$($this.BaseUri)/administrativeUnits/$AuId"
+        $uri += '?$select=id,displayName'
+
+        try {
+            $au = $this.InvokeGraphRequest('GET', $uri, $AccessToken, $null)
+            return $au
+        }
+        catch {
+            if ($_.Exception.Message -match '404|not found|does not exist') {
+                return $null
+            }
+            throw
+        }
+    } -Force
+
+    $adapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $ObjectId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AccessToken
+        )
+
+        $uri = "$($this.BaseUri)/users/$ObjectId/memberOf/microsoft.graph.administrativeUnit"
+        $uri += '?$select=id,displayName'
+
+        $aus = $this.GetAllPages($uri, $AccessToken)
+        return $aus
+    } -Force
+
+    $adapter | Add-Member -MemberType ScriptMethod -Name AddAdministrativeUnitMember -Value {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AuObjectId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $UserObjectId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AccessToken
+        )
+
+        $uri = "$($this.BaseUri)/administrativeUnits/$AuObjectId/members/`$ref"
+        $body = @{
+            '@odata.id' = "$($this.BaseUri)/users/$UserObjectId"
+        }
+
+        try {
+            $null = $this.InvokeGraphRequest('POST', $uri, $AccessToken, $body)
+            return $true
+        }
+        catch {
+            if ($_.Exception.Message -match 'already exists|already a member') {
+                return $false
+            }
+            throw
+        }
+    } -Force
+
+    $adapter | Add-Member -MemberType ScriptMethod -Name RemoveAdministrativeUnitMember -Value {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AuObjectId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $UserObjectId,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AccessToken
+        )
+
+        $uri = "$($this.BaseUri)/administrativeUnits/$AuObjectId/members/$UserObjectId/`$ref"
+
+        try {
+            $null = $this.InvokeGraphRequest('DELETE', $uri, $AccessToken, $null)
+            return $true
+        }
+        catch {
+            if ($_.Exception.Message -match '404|not found|does not exist') {
+                return $false
+            }
+            throw
+        }
     } -Force
 
     $adapter | Add-Member -MemberType ScriptMethod -Name AddGroupMember -Value {

--- a/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
+++ b/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
@@ -405,6 +405,34 @@ function New-IdleEntraIDAdapter {
         }
     } -Force
 
+    $adapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitByDisplayName -Value {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $DisplayName,
+
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AccessToken
+        )
+
+        $encodedName = [System.Net.WebUtility]::UrlEncode($DisplayName)
+        $uri = "$($this.BaseUri)/directory/administrativeUnits?`$filter=displayName eq '$encodedName'"
+        $uri += '&$select=id,displayName'
+
+        $aus = $this.InvokeGraphRequest('GET', $uri, $AccessToken, $null)
+
+        if (-not $aus.value -or $aus.value.Count -eq 0) {
+            return $null
+        }
+
+        if ($aus.value.Count -gt 1) {
+            throw "Multiple Administrative Units found with displayName '$DisplayName'. Use objectId for deterministic lookup."
+        }
+
+        return $aus.value[0]
+    } -Force
+
     $adapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
         param(
             [Parameter(Mandatory)]

--- a/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
+++ b/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
@@ -390,7 +390,7 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $uri = "$($this.BaseUri)/administrativeUnits/$AuId"
+        $uri = "$($this.BaseUri)/directory/administrativeUnits/$AuId"
         $uri += '?$select=id,displayName'
 
         try {
@@ -438,7 +438,7 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $uri = "$($this.BaseUri)/administrativeUnits/$AuObjectId/members/`$ref"
+        $uri = "$($this.BaseUri)/directory/administrativeUnits/$AuObjectId/members/`$ref"
         $body = @{
             '@odata.id' = "$($this.BaseUri)/users/$UserObjectId"
         }
@@ -470,7 +470,7 @@ function New-IdleEntraIDAdapter {
             [string] $AccessToken
         )
 
-        $uri = "$($this.BaseUri)/administrativeUnits/$AuObjectId/members/$UserObjectId/`$ref"
+        $uri = "$($this.BaseUri)/directory/administrativeUnits/$AuObjectId/members/$UserObjectId/`$ref"
 
         try {
             $null = $this.InvokeGraphRequest('DELETE', $uri, $AccessToken, $null)

--- a/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
+++ b/src/IdLE.Provider.EntraID/Private/New-IdleEntraIDAdapter.ps1
@@ -75,8 +75,11 @@ function New-IdleEntraIDAdapter {
             if ($_.Exception.Response) {
                 $statusCode = [int]$_.Exception.Response.StatusCode
                 if ($_.Exception.Response.Headers) {
-                    $requestId = $_.Exception.Response.Headers['request-id']
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    # HttpResponseHeaders (PowerShell 7 / HttpClient) does not support
+                    # indexer-style access. Use GetValues() with a safety catch for the
+                    # case where the header is absent (GetValues throws in that case).
+                    try { $requestId  = $_.Exception.Response.Headers.GetValues('request-id')   | Select-Object -First 1 } catch { }
+                    try { $retryAfter = $_.Exception.Response.Headers.GetValues('Retry-After')  | Select-Object -First 1 } catch { }
                 }
             }
 

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -284,6 +284,31 @@ function New-IdleEntraIDIdentityProvider {
         throw "Group '$GroupId' not found."
     }
 
+    $resolveAdministrativeUnit = {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            [string] $AuId,
+
+            [Parameter()]
+            [AllowNull()]
+            [object] $AuthSession
+        )
+
+        $accessToken = $this.ExtractAccessToken($AuthSession)
+
+        $guid = [System.Guid]::Empty
+        if ([System.Guid]::TryParse($AuId, [ref]$guid)) {
+            $au = $this.Adapter.GetAdministrativeUnitById($AuId, $accessToken)
+            if ($null -ne $au) {
+                return $au.id
+            }
+            throw "Administrative Unit with objectId '$AuId' not found."
+        }
+
+        throw "Administrative Unit '$AuId' is not a valid objectId (GUID). Administrative Units must be referenced by their Entra object ID."
+    }
+
     $provider = [pscustomobject]@{
         PSTypeName  = 'IdLE.Provider.EntraIDIdentityProvider'
         Name        = 'EntraIDIdentityProvider'
@@ -296,6 +321,7 @@ function New-IdleEntraIDIdentityProvider {
     $provider | Add-Member -MemberType ScriptMethod -Name TestEntitlementEquals -Value $testEntitlementEquals -Force
     $provider | Add-Member -MemberType ScriptMethod -Name ResolveIdentity -Value $resolveIdentity -Force
     $provider | Add-Member -MemberType ScriptMethod -Name ResolveGroup -Value $resolveGroup -Force
+    $provider | Add-Member -MemberType ScriptMethod -Name ResolveAdministrativeUnit -Value $resolveAdministrativeUnit -Force
 
     $provider | Add-Member -MemberType ScriptMethod -Name GetCapabilities -Value {
         $caps = @(
@@ -805,6 +831,7 @@ function New-IdleEntraIDIdentityProvider {
         $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
 
         $groups = $this.Adapter.ListUserGroups($user.id, $accessToken)
+        $aus = $this.Adapter.ListUserAdministrativeUnits($user.id, $accessToken)
 
         $result = @()
         foreach ($group in $groups) {
@@ -829,6 +856,16 @@ function New-IdleEntraIDIdentityProvider {
             }
         }
 
+        foreach ($au in $aus) {
+            $auId = if ($au -is [System.Collections.IDictionary]) { $au['id'] } else { $au.id }
+
+            $result += [pscustomobject]@{
+                PSTypeName = 'IdLE.Entitlement'
+                Kind       = 'AdministrativeUnit'
+                Id         = $auId
+            }
+        }
+
         return $result
     } -Force
 
@@ -850,26 +887,28 @@ function New-IdleEntraIDIdentityProvider {
         $accessToken = $this.ExtractAccessToken($AuthSession)
         $normalized = $this.ConvertToEntitlement($Entitlement)
 
-        # GrantEntitlement only supports group entitlements
-        if ($null -ne $normalized.Kind -and $normalized.Kind -ne 'Group') {
-            throw [System.ArgumentException]::new(
-                "GrantEntitlement only supports entitlements with Kind 'Group'. Received Kind '$($normalized.Kind)'."
-            )
-        }
-
         # Default missing Kind to 'Group' for backward compatibility
         if (-not $normalized.Kind) {
             $normalized.Kind = 'Group'
         }
 
-        $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
-        $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
-
-        # Update normalized entitlement with canonical group ID
-        $normalized.Id = $groupObjectId
-
-        # Adapter handles idempotency (already a member → no-op); returns $true if changed
-        $changed = [bool]$this.Adapter.AddGroupMember($groupObjectId, $user.id, $accessToken)
+        if ($normalized.Kind -eq 'AdministrativeUnit') {
+            $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
+            $auObjectId = $this.ResolveAdministrativeUnit($normalized.Id, $AuthSession)
+            $normalized.Id = $auObjectId
+            $changed = [bool]$this.Adapter.AddAdministrativeUnitMember($auObjectId, $user.id, $accessToken)
+        }
+        elseif ($normalized.Kind -eq 'Group') {
+            $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
+            $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
+            $normalized.Id = $groupObjectId
+            $changed = [bool]$this.Adapter.AddGroupMember($groupObjectId, $user.id, $accessToken)
+        }
+        else {
+            throw [System.ArgumentException]::new(
+                "GrantEntitlement only supports entitlements with Kind 'Group' or 'AdministrativeUnit'. Received Kind '$($normalized.Kind)'."
+            )
+        }
 
         return [pscustomobject]@{
             PSTypeName  = 'IdLE.ProviderResult'
@@ -898,25 +937,28 @@ function New-IdleEntraIDIdentityProvider {
         $accessToken = $this.ExtractAccessToken($AuthSession)
         $normalized = $this.ConvertToEntitlement($Entitlement)
 
-        # RevokeEntitlement only supports group entitlements
-        if ($null -ne $normalized.Kind -and $normalized.Kind -ne 'Group') {
-            throw [System.ArgumentException]::new(
-                "RevokeEntitlement only supports entitlements with Kind 'Group'. Received Kind '$($normalized.Kind)'."
-            )
-        }
-
         # Default missing Kind to 'Group' for backward compatibility
         if (-not $normalized.Kind) {
             $normalized.Kind = 'Group'
         }
-        $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
-        $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
 
-        # Update normalized entitlement with canonical group ID
-        $normalized.Id = $groupObjectId
-
-        # Adapter handles idempotency (not a member → no-op); returns $true if changed
-        $changed = [bool]$this.Adapter.RemoveGroupMember($groupObjectId, $user.id, $accessToken)
+        if ($normalized.Kind -eq 'AdministrativeUnit') {
+            $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
+            $auObjectId = $this.ResolveAdministrativeUnit($normalized.Id, $AuthSession)
+            $normalized.Id = $auObjectId
+            $changed = [bool]$this.Adapter.RemoveAdministrativeUnitMember($auObjectId, $user.id, $accessToken)
+        }
+        elseif ($normalized.Kind -eq 'Group') {
+            $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
+            $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
+            $normalized.Id = $groupObjectId
+            $changed = [bool]$this.Adapter.RemoveGroupMember($groupObjectId, $user.id, $accessToken)
+        }
+        else {
+            throw [System.ArgumentException]::new(
+                "RevokeEntitlement only supports entitlements with Kind 'Group' or 'AdministrativeUnit'. Received Kind '$($normalized.Kind)'."
+            )
+        }
 
         return [pscustomobject]@{
             PSTypeName  = 'IdLE.ProviderResult'
@@ -1069,6 +1111,15 @@ function New-IdleEntraIDIdentityProvider {
         $null = $Kind  # Contract parameter — reserved for future multi-Kind dispatch
         if ([string]::Equals($converted.Kind, 'Group', [System.StringComparison]::OrdinalIgnoreCase)) {
             $canonicalId = $this.ResolveGroup($converted.Id, $AuthSession)
+            return [pscustomobject]@{
+                PSTypeName = 'IdLE.Entitlement'
+                Kind       = $converted.Kind
+                Id         = $canonicalId
+            }
+        }
+
+        if ([string]::Equals($converted.Kind, 'AdministrativeUnit', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $canonicalId = $this.ResolveAdministrativeUnit($converted.Id, $AuthSession)
             return [pscustomobject]@{
                 PSTypeName = 'IdLE.Entitlement'
                 Kind       = $converted.Kind

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -996,49 +996,83 @@ function New-IdleEntraIDIdentityProvider {
         $accessToken = $this.ExtractAccessToken($AuthSession)
         $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
 
-        $operations = @()
+        # Split entitlements by kind: Groups use the Graph $batch path; AUs are processed per-item
+        # (no Graph batch API exists for Administrative Unit membership changes).
+        $groupOperations            = @()
+        $administrativeUnitResults  = @()
+
         foreach ($ent in $Entitlements) {
             $normalized = $this.ConvertToEntitlement($ent)
-            if ($null -ne $normalized.Kind -and $normalized.Kind -ne 'Group') {
+            if (-not $normalized.Kind) { $normalized.Kind = 'Group' }
+
+            if ($normalized.Kind -eq 'Group') {
+                $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
+                $normalized.Id = $groupObjectId
+                $groupOperations += @{
+                    RequestId     = [guid]::NewGuid().ToString('N').Substring(0, 8)
+                    GroupObjectId = $groupObjectId
+                    UserObjectId  = $user.id
+                    Action        = 'remove'
+                    Entitlement   = $normalized
+                }
+            }
+            elseif ($normalized.Kind -eq 'AdministrativeUnit') {
+                $auObjectId = $this.ResolveAdministrativeUnit($normalized.Id, $AuthSession)
+                $normalized.Id = $auObjectId
+                try {
+                    $changed = [bool]$this.Adapter.RemoveAdministrativeUnitMember($auObjectId, $user.id, $accessToken)
+                    $administrativeUnitResults += [pscustomobject]@{
+                        PSTypeName  = 'IdLE.BulkProviderResult'
+                        Operation   = 'RevokeEntitlement'
+                        IdentityKey = $IdentityKey
+                        Changed     = $changed
+                        Error       = $null
+                        Entitlement = $normalized
+                    }
+                }
+                catch {
+                    $administrativeUnitResults += [pscustomobject]@{
+                        PSTypeName  = 'IdLE.BulkProviderResult'
+                        Operation   = 'RevokeEntitlement'
+                        IdentityKey = $IdentityKey
+                        Changed     = $false
+                        Error       = $_.Exception.Message
+                        Entitlement = $normalized
+                    }
+                }
+            }
+            else {
                 throw [System.ArgumentException]::new(
-                    "BulkRevokeEntitlements only supports entitlements with Kind 'Group'. Received Kind '$($normalized.Kind)'."
+                    "BulkRevokeEntitlements only supports entitlements with Kind 'Group' or 'AdministrativeUnit'. Received Kind '$($normalized.Kind)'."
                 )
             }
-            $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
-            $normalized.Id = $groupObjectId
-            $operations += @{
-                RequestId     = [guid]::NewGuid().ToString('N').Substring(0, 8)
-                GroupObjectId = $groupObjectId
-                UserObjectId  = $user.id
-                Action        = 'remove'
-                Entitlement   = $normalized
-            }
-        }
-
-        if ($operations.Count -eq 0) {
-            return @()
-        }
-
-        $batchResults = $this.Adapter.BatchMembershipChanges($operations, $accessToken)
-
-        # Build lookup table for operations by RequestId to avoid O(n²) Where-Object scans
-        $operationByRequestId = @{}
-        foreach ($op in $operations) {
-            $operationByRequestId[$op.RequestId] = $op
         }
 
         $results = @()
-        foreach ($br in $batchResults) {
-            $op = $operationByRequestId[$br.RequestId]
-            $results += [pscustomobject]@{
-                PSTypeName  = 'IdLE.BulkProviderResult'
-                Operation   = 'RevokeEntitlement'
-                IdentityKey = $IdentityKey
-                Changed     = $br.Changed
-                Error       = $br.Error
-                Entitlement = $op.Entitlement
+
+        if ($groupOperations.Count -gt 0) {
+            $batchResults = $this.Adapter.BatchMembershipChanges($groupOperations, $accessToken)
+
+            # Build lookup table by RequestId to avoid O(n²) Where-Object scans
+            $operationByRequestId = @{}
+            foreach ($op in $groupOperations) {
+                $operationByRequestId[$op.RequestId] = $op
+            }
+
+            foreach ($br in $batchResults) {
+                $op = $operationByRequestId[$br.RequestId]
+                $results += [pscustomobject]@{
+                    PSTypeName  = 'IdLE.BulkProviderResult'
+                    Operation   = 'RevokeEntitlement'
+                    IdentityKey = $IdentityKey
+                    Changed     = $br.Changed
+                    Error       = $br.Error
+                    Entitlement = $op.Entitlement
+                }
             }
         }
+
+        $results += $administrativeUnitResults
         return $results
     } -Force
 

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -1094,43 +1094,83 @@ function New-IdleEntraIDIdentityProvider {
         $accessToken = $this.ExtractAccessToken($AuthSession)
         $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
 
-        $operations = @()
+        # Split entitlements by kind: Groups use the Graph $batch path; AUs are processed per-item
+        # (no Graph batch API exists for Administrative Unit membership changes).
+        $groupOperations            = @()
+        $administrativeUnitResults  = @()
+
         foreach ($ent in $Entitlements) {
             $normalized = $this.ConvertToEntitlement($ent)
-            if ($null -ne $normalized.Kind -and $normalized.Kind -ne 'Group') {
+            if (-not $normalized.Kind) { $normalized.Kind = 'Group' }
+
+            if ($normalized.Kind -eq 'Group') {
+                $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
+                $normalized.Id = $groupObjectId
+                $groupOperations += @{
+                    RequestId     = [guid]::NewGuid().ToString('N').Substring(0, 8)
+                    GroupObjectId = $groupObjectId
+                    UserObjectId  = $user.id
+                    Action        = 'add'
+                    Entitlement   = $normalized
+                }
+            }
+            elseif ($normalized.Kind -eq 'AdministrativeUnit') {
+                $auObjectId = $this.ResolveAdministrativeUnit($normalized.Id, $AuthSession)
+                $normalized.Id = $auObjectId
+                try {
+                    $changed = [bool]$this.Adapter.AddAdministrativeUnitMember($auObjectId, $user.id, $accessToken)
+                    $administrativeUnitResults += [pscustomobject]@{
+                        PSTypeName  = 'IdLE.BulkProviderResult'
+                        Operation   = 'GrantEntitlement'
+                        IdentityKey = $IdentityKey
+                        Changed     = $changed
+                        Error       = $null
+                        Entitlement = $normalized
+                    }
+                }
+                catch {
+                    $administrativeUnitResults += [pscustomobject]@{
+                        PSTypeName  = 'IdLE.BulkProviderResult'
+                        Operation   = 'GrantEntitlement'
+                        IdentityKey = $IdentityKey
+                        Changed     = $false
+                        Error       = $_.Exception.Message
+                        Entitlement = $normalized
+                    }
+                }
+            }
+            else {
                 throw [System.ArgumentException]::new(
-                    "BulkGrantEntitlements only supports entitlements with Kind 'Group'. Received Kind '$($normalized.Kind)'."
+                    "BulkGrantEntitlements only supports entitlements with Kind 'Group' or 'AdministrativeUnit'. Received Kind '$($normalized.Kind)'."
                 )
             }
-            $groupObjectId = $this.ResolveGroup($normalized.Id, $AuthSession)
-            $normalized.Id = $groupObjectId
-            $operations += @{
-                RequestId     = [guid]::NewGuid().ToString('N').Substring(0, 8)
-                GroupObjectId = $groupObjectId
-                UserObjectId  = $user.id
-                Action        = 'add'
-                Entitlement   = $normalized
-            }
         }
-
-        if ($operations.Count -eq 0) {
-            return @()
-        }
-
-        $batchResults = $this.Adapter.BatchMembershipChanges($operations, $accessToken)
 
         $results = @()
-        foreach ($br in $batchResults) {
-            $op = $operations | Where-Object { $_.RequestId -eq $br.RequestId }
-            $results += [pscustomobject]@{
-                PSTypeName  = 'IdLE.BulkProviderResult'
-                Operation   = 'GrantEntitlement'
-                IdentityKey = $IdentityKey
-                Changed     = $br.Changed
-                Error       = $br.Error
-                Entitlement = $op.Entitlement
+
+        if ($groupOperations.Count -gt 0) {
+            $batchResults = $this.Adapter.BatchMembershipChanges($groupOperations, $accessToken)
+
+            # Build lookup table by RequestId to avoid O(n²) Where-Object scans
+            $operationByRequestId = @{}
+            foreach ($op in $groupOperations) {
+                $operationByRequestId[$op.RequestId] = $op
+            }
+
+            foreach ($br in $batchResults) {
+                $op = $operationByRequestId[$br.RequestId]
+                $results += [pscustomobject]@{
+                    PSTypeName  = 'IdLE.BulkProviderResult'
+                    Operation   = 'GrantEntitlement'
+                    IdentityKey = $IdentityKey
+                    Changed     = $br.Changed
+                    Error       = $br.Error
+                    Entitlement = $op.Entitlement
+                }
             }
         }
+
+        $results += $administrativeUnitResults
         return $results
     } -Force
 

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -299,6 +299,7 @@ function New-IdleEntraIDIdentityProvider {
 
         $accessToken = $this.ExtractAccessToken($AuthSession)
 
+        # Try as objectId first
         $guid = [System.Guid]::Empty
         if ([System.Guid]::TryParse($AuId, [ref]$guid)) {
             $au = $this.Adapter.GetAdministrativeUnitById($AuId, $accessToken)
@@ -308,7 +309,13 @@ function New-IdleEntraIDIdentityProvider {
             throw "Administrative Unit with objectId '$AuId' not found."
         }
 
-        throw "Administrative Unit '$AuId' is not a valid objectId (GUID). Administrative Units must be referenced by their Entra object ID."
+        # Try as displayName
+        $au = $this.Adapter.GetAdministrativeUnitByDisplayName($AuId, $accessToken)
+        if ($null -ne $au) {
+            return $au.id
+        }
+
+        throw "Administrative Unit '$AuId' not found."
     }
 
     $provider = [pscustomobject]@{

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -82,7 +82,7 @@ function New-IdleEntraIDIdentityProvider {
     Requires Microsoft Graph API permissions (delegated or app-only):
     - User.Read.All, User.ReadWrite.All
     - Group.Read.All, GroupMember.ReadWrite.All
-    - AdministrativeUnit.Read.All (for ListEntitlements with Kind=AdministrativeUnit)
+    - AdministrativeUnit.Read.All (for ListEntitlements/GrantEntitlement/RevokeEntitlement with Kind=AdministrativeUnit)
     - AdministrativeUnit.ReadWrite.All (for Grant/Revoke with Kind=AdministrativeUnit)
     - For delete: User.ReadWrite.All
 
@@ -833,45 +833,60 @@ function New-IdleEntraIDIdentityProvider {
 
             [Parameter()]
             [AllowNull()]
-            [object] $AuthSession
+            [object] $AuthSession,
+
+            [Parameter()]
+            [AllowNull()]
+            [string] $Kind = $null
         )
 
         $accessToken = $this.ExtractAccessToken($AuthSession)
         $user = $this.ResolveIdentity($IdentityKey, $AuthSession)
 
-        $groups = $this.Adapter.ListUserGroups($user.id, $accessToken)
-        $aus = $this.Adapter.ListUserAdministrativeUnits($user.id, $accessToken)
+        # When Kind is supplied, only fetch the relevant directory objects.
+        # When Kind is null/empty, fetch both (backward-compatible, e.g. host-level reports).
+        $includeGroups = [string]::IsNullOrEmpty($Kind) -or
+            [string]::Equals($Kind, 'Group', [System.StringComparison]::OrdinalIgnoreCase)
+        $includeAUs    = [string]::IsNullOrEmpty($Kind) -or
+            [string]::Equals($Kind, 'AdministrativeUnit', [System.StringComparison]::OrdinalIgnoreCase)
 
         $result = @()
-        foreach ($group in $groups) {
-            # Handle both hashtables and PSCustomObjects
-            $groupId = if ($group -is [System.Collections.IDictionary]) {
-                $group['id']
-            } else {
-                $group.id
-            }
 
-            $mail = if ($group -is [System.Collections.IDictionary]) {
-                if ($group.ContainsKey('mail')) { $group['mail'] } else { $null }
-            } else {
-                if ($group.PSObject.Properties.Name -contains 'mail') { $group.mail } else { $null }
-            }
+        if ($includeGroups) {
+            $groups = $this.Adapter.ListUserGroups($user.id, $accessToken)
+            foreach ($group in $groups) {
+                # Handle both hashtables and PSCustomObjects
+                $groupId = if ($group -is [System.Collections.IDictionary]) {
+                    $group['id']
+                } else {
+                    $group.id
+                }
 
-            $result += [pscustomobject]@{
-                PSTypeName = 'IdLE.Entitlement'
-                Kind       = 'Group'
-                Id         = $groupId
-                Mail       = $mail
+                $mail = if ($group -is [System.Collections.IDictionary]) {
+                    if ($group.ContainsKey('mail')) { $group['mail'] } else { $null }
+                } else {
+                    if ($group.PSObject.Properties.Name -contains 'mail') { $group.mail } else { $null }
+                }
+
+                $result += [pscustomobject]@{
+                    PSTypeName = 'IdLE.Entitlement'
+                    Kind       = 'Group'
+                    Id         = $groupId
+                    Mail       = $mail
+                }
             }
         }
 
-        foreach ($au in $aus) {
-            $auId = if ($au -is [System.Collections.IDictionary]) { $au['id'] } else { $au.id }
+        if ($includeAUs) {
+            $aus = $this.Adapter.ListUserAdministrativeUnits($user.id, $accessToken)
+            foreach ($au in $aus) {
+                $auId = if ($au -is [System.Collections.IDictionary]) { $au['id'] } else { $au.id }
 
-            $result += [pscustomobject]@{
-                PSTypeName = 'IdLE.Entitlement'
-                Kind       = 'AdministrativeUnit'
-                Id         = $auId
+                $result += [pscustomobject]@{
+                    PSTypeName = 'IdLE.Entitlement'
+                    Kind       = 'AdministrativeUnit'
+                    Id         = $auId
+                }
             }
         }
 

--- a/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
+++ b/src/IdLE.Provider.EntraID/Public/New-IdleEntraIDIdentityProvider.ps1
@@ -9,7 +9,7 @@ function New-IdleEntraIDIdentityProvider {
     via the host-provided AuthSessionBroker pattern.
 
     The provider supports common identity operations (Create, Read, Disable, Enable, Delete)
-    and group entitlement management (List, Grant, Revoke).
+    and entitlement management for groups and Administrative Units (List, Grant, Revoke).
 
     Identity addressing supports:
     - objectId (GUID string) - most deterministic
@@ -37,7 +37,7 @@ function New-IdleEntraIDIdentityProvider {
 
     .PARAMETER Adapter
     Internal parameter for dependency injection during testing. Allows unit tests to inject
-    a fake Graph adapter without requiring a real Entra ID environment.
+    a mock Graph adapter without requiring a real Entra ID environment.
 
     .EXAMPLE
     # Basic usage with delegated auth
@@ -82,6 +82,8 @@ function New-IdleEntraIDIdentityProvider {
     Requires Microsoft Graph API permissions (delegated or app-only):
     - User.Read.All, User.ReadWrite.All
     - Group.Read.All, GroupMember.ReadWrite.All
+    - AdministrativeUnit.Read.All (for ListEntitlements with Kind=AdministrativeUnit)
+    - AdministrativeUnit.ReadWrite.All (for Grant/Revoke with Kind=AdministrativeUnit)
     - For delete: User.ReadWrite.All
 
     See docs/reference/providers/provider-entraID.md for detailed permission requirements.

--- a/src/IdLE.Steps.Common/Public/Invoke-IdleStepEnsureEntitlement.ps1
+++ b/src/IdLE.Steps.Common/Public/Invoke-IdleStepEnsureEntitlement.ps1
@@ -178,13 +178,20 @@ function Invoke-IdleStepEnsureEntitlement {
 
     # Check AuthSession support for each method
     $listSupportsAuthSession = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['ListEntitlements'] -ParameterName 'AuthSession'
+    $listSupportsKind = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['ListEntitlements'] -ParameterName 'Kind'
     $grantSupportsAuthSession = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['GrantEntitlement'] -ParameterName 'AuthSession'
     $revokeSupportsAuthSession = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['RevokeEntitlement'] -ParameterName 'AuthSession'
 
-    if ($listSupportsAuthSession -and $null -ne $authSession) {
+    # Pass Kind to the provider when supported, so it can skip fetching unrelated objects
+    # (e.g. avoid AU Graph calls for a Group entitlement check).
+    $entitlementKind = [string]$entitlement.Kind
+    if ($listSupportsKind -and $listSupportsAuthSession -and $null -ne $authSession) {
+        $current = @($provider.ListEntitlements($identityKey, $authSession, $entitlementKind))
+    } elseif ($listSupportsKind) {
+        $current = @($provider.ListEntitlements($identityKey, $null, $entitlementKind))
+    } elseif ($listSupportsAuthSession -and $null -ne $authSession) {
         $current = @($provider.ListEntitlements($identityKey, $authSession))
-    }
-    else {
+    } else {
         $current = @($provider.ListEntitlements($identityKey))
     }
     $matches = @($current | Where-Object { Test-IdleStepEntitlementEquals -A $_ -B $entitlement })

--- a/src/IdLE.Steps.Common/Public/Invoke-IdleStepPruneEntitlements.ps1
+++ b/src/IdLE.Steps.Common/Public/Invoke-IdleStepPruneEntitlements.ps1
@@ -222,6 +222,7 @@ function Invoke-IdleStepPruneEntitlements {
     }
 
     $listSupportsAuthSession = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['ListEntitlements'] -ParameterName 'AuthSession'
+    $listSupportsKind = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['ListEntitlements'] -ParameterName 'Kind'
     $revokeSupportsAuthSession = Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['RevokeEntitlement'] -ParameterName 'AuthSession'
     $grantSupportsAuthSession = if ($ensureKeep) {
         Test-IdleProviderMethodParameter -ProviderMethod $provider.PSObject.Methods['GrantEntitlement'] -ParameterName 'AuthSession'
@@ -238,7 +239,13 @@ function Invoke-IdleStepPruneEntitlements {
     } else { $false }
 
     # 1. List current entitlements, filter by Kind
-    $allCurrent = if ($listSupportsAuthSession -and $null -ne $authSession) {
+    # When the provider supports the Kind parameter, pass it so the provider can skip
+    # fetching unrelated directory objects (e.g. avoid AU Graph calls for Group-only prunes).
+    $allCurrent = if ($listSupportsKind -and $listSupportsAuthSession -and $null -ne $authSession) {
+        @($provider.ListEntitlements($identityKey, $authSession, $kind))
+    } elseif ($listSupportsKind) {
+        @($provider.ListEntitlements($identityKey, $null, $kind))
+    } elseif ($listSupportsAuthSession -and $null -ne $authSession) {
         @($provider.ListEntitlements($identityKey, $authSession))
     } else {
         @($provider.ListEntitlements($identityKey))

--- a/tests/Providers/EntraIDIdentityProvider.Tests.ps1
+++ b/tests/Providers/EntraIDIdentityProvider.Tests.ps1
@@ -1094,6 +1094,56 @@ Describe 'EntraID identity provider - Entitlement operations' {
             $results[0].Error | Should -BeNullOrEmpty
         }
 
+        It 'BulkGrantEntitlements adds an AdministrativeUnit membership and returns Changed=$true' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            $results = $script:EntProvider.BulkGrantEntitlements($userId, @(
+                @{ Kind = 'AdministrativeUnit'; Id = $auId }
+            ))
+
+            @($results).Count | Should -Be 1
+            $results[0].Changed | Should -Be $true
+            $results[0].Error | Should -BeNullOrEmpty
+            $results[0].Entitlement.Kind | Should -Be 'AdministrativeUnit'
+
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 1
+        }
+
+        It 'BulkGrantEntitlements is idempotent for AdministrativeUnit (already a member → Changed=$false)' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $results = $script:EntProvider.BulkGrantEntitlements($userId, @(
+                @{ Kind = 'AdministrativeUnit'; Id = $auId }
+            ))
+
+            @($results).Count | Should -Be 1
+            $results[0].Changed | Should -Be $false
+            $results[0].Error | Should -BeNullOrEmpty
+        }
+
+        It 'BulkGrantEntitlements handles mixed Group and AdministrativeUnit in a single call' {
+            $userId  = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $groupId = [guid]::NewGuid().ToString()
+            $auId    = [guid]::NewGuid().ToString()
+
+            $results = $script:EntProvider.BulkGrantEntitlements($userId, @(
+                @{ Kind = 'Group';               Id = $groupId },
+                @{ Kind = 'AdministrativeUnit'; Id = $auId    }
+            ))
+
+            @($results).Count | Should -Be 2
+            ($results | Where-Object { $_.Changed -eq $true }).Count | Should -Be 2
+
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'Group'               -and $_.Id -eq $groupId }).Count | Should -Be 1
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId    }).Count | Should -Be 1
+        }
+
         It 'BulkRevokeEntitlements removes an AdministrativeUnit membership and returns Changed=$true' {
             $userId = [guid]::NewGuid().ToString()
             [void]$script:EntProvider.GetIdentity($userId)

--- a/tests/Providers/EntraIDIdentityProvider.Tests.ps1
+++ b/tests/Providers/EntraIDIdentityProvider.Tests.ps1
@@ -1094,6 +1094,58 @@ Describe 'EntraID identity provider - Entitlement operations' {
             $results[0].Error | Should -BeNullOrEmpty
         }
 
+        It 'BulkRevokeEntitlements removes an AdministrativeUnit membership and returns Changed=$true' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $results = $script:EntProvider.BulkRevokeEntitlements($userId, @(
+                @{ Kind = 'AdministrativeUnit'; Id = $auId }
+            ))
+
+            @($results).Count | Should -Be 1
+            $results[0].Changed | Should -Be $true
+            $results[0].Error | Should -BeNullOrEmpty
+            $results[0].Entitlement.Kind | Should -Be 'AdministrativeUnit'
+
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 0
+        }
+
+        It 'BulkRevokeEntitlements is idempotent for AdministrativeUnit (not a member → Changed=$false)' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            $results = $script:EntProvider.BulkRevokeEntitlements($userId, @(
+                @{ Kind = 'AdministrativeUnit'; Id = $auId }
+            ))
+
+            @($results).Count | Should -Be 1
+            $results[0].Changed | Should -Be $false
+            $results[0].Error | Should -BeNullOrEmpty
+        }
+
+        It 'BulkRevokeEntitlements handles mixed Group and AdministrativeUnit in a single call' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $groupId = [guid]::NewGuid().ToString()
+            $auId    = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'Group';               Id = $groupId })
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId    })
+
+            $results = $script:EntProvider.BulkRevokeEntitlements($userId, @(
+                @{ Kind = 'Group';               Id = $groupId },
+                @{ Kind = 'AdministrativeUnit'; Id = $auId    }
+            ))
+
+            @($results).Count | Should -Be 2
+            ($results | Where-Object { $_.Changed -eq $true }).Count | Should -Be 2
+
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'Group' -and $_.Id -eq $groupId }).Count | Should -Be 0
+            @($script:EntProvider.ListEntitlements($userId) | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 0
+        }
+
         It 'GrantEntitlement returns stable result shape with Kind=AdministrativeUnit' {
             $userId = [guid]::NewGuid().ToString()
             [void]$script:EntProvider.GetIdentity($userId)

--- a/tests/Providers/EntraIDIdentityProvider.Tests.ps1
+++ b/tests/Providers/EntraIDIdentityProvider.Tests.ps1
@@ -35,13 +35,13 @@ BeforeDiscovery {
 
 Describe 'EntraID identity provider - Contract tests' {
     BeforeAll {
-        # Create a fake adapter for contract tests
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+        # Create a mock adapter for contract tests
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
             Store      = @{}
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             $key = "id:$ObjectId"
             if (-not $this.Store.ContainsKey($key)) {
@@ -58,7 +58,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $this.Store[$key]
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
             param($Upn, $AccessToken)
             # Try direct lookup first
             if ($this.Store.ContainsKey("upn:$Upn")) {
@@ -73,7 +73,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
             param($Mail, $AccessToken)
             # Try direct lookup first
             if ($this.Store.ContainsKey("mail:$Mail")) {
@@ -88,7 +88,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
             param($Payload, $AccessToken)
             $id = [guid]::NewGuid().ToString()
             $user = @{
@@ -108,7 +108,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $user
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name PatchUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name PatchUser -Value {
             param($ObjectId, $Payload, $AccessToken)
             $key = "id:$ObjectId"
             if ($this.Store.ContainsKey($key)) {
@@ -118,7 +118,7 @@ Describe 'EntraID identity provider - Contract tests' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name DeleteUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name DeleteUser -Value {
             param($ObjectId, $AccessToken)
             $key = "id:$ObjectId"
             if ($this.Store.ContainsKey($key)) {
@@ -126,7 +126,7 @@ Describe 'EntraID identity provider - Contract tests' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name ListUsers -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name ListUsers -Value {
             param($Filter, $AccessToken)
             $users = @()
             foreach ($key in $this.Store.Keys) {
@@ -135,7 +135,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $users
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
             param($GroupId, $AccessToken)
             return @{
                 id          = $GroupId
@@ -144,7 +144,7 @@ Describe 'EntraID identity provider - Contract tests' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
             param($DisplayName, $AccessToken)
             # Generate a deterministic GUID based on the display name
             # This simulates real Graph API behavior where groups have GUID ids
@@ -159,7 +159,7 @@ Describe 'EntraID identity provider - Contract tests' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name ListUserGroups -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name ListUserGroups -Value {
             param($ObjectId, $AccessToken)
             $key = "groups:$ObjectId"
             if (-not $this.Store.ContainsKey($key)) {
@@ -168,7 +168,44 @@ Describe 'EntraID identity provider - Contract tests' {
             return $this.Store[$key]
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name AddGroupMember -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+            param($AuId, $AccessToken)
+            return @{ id = $AuId; displayName = "AU $AuId" }
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
+            param($ObjectId, $AccessToken)
+            $key = "aus:$ObjectId"
+            if (-not $this.Store.ContainsKey($key)) {
+                $this.Store[$key] = @()
+            }
+            return $this.Store[$key]
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name AddAdministrativeUnitMember -Value {
+            param($AuObjectId, $UserObjectId, $AccessToken)
+            $key = "aus:$UserObjectId"
+            if (-not $this.Store.ContainsKey($key)) { $this.Store[$key] = @() }
+            $alreadyMember = $null -ne ($this.Store[$key] | Where-Object { $_.id -eq $AuObjectId })
+            if (-not $alreadyMember) {
+                $this.Store[$key] += @{ id = $AuObjectId; displayName = "AU $AuObjectId" }
+                return $true
+            }
+            return $false
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name RemoveAdministrativeUnitMember -Value {
+            param($AuObjectId, $UserObjectId, $AccessToken)
+            $key = "aus:$UserObjectId"
+            if ($this.Store.ContainsKey($key)) {
+                $wasMember = $null -ne ($this.Store[$key] | Where-Object { $_.id -eq $AuObjectId })
+                $this.Store[$key] = @($this.Store[$key] | Where-Object { $_.id -ne $AuObjectId })
+                return $wasMember
+            }
+            return $false
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name AddGroupMember -Value {
             param($GroupObjectId, $UserObjectId, $AccessToken)
             $key = "groups:$UserObjectId"
             if (-not $this.Store.ContainsKey($key)) {
@@ -195,7 +232,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $false
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name RemoveGroupMember -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name RemoveGroupMember -Value {
             param($GroupObjectId, $UserObjectId, $AccessToken)
             $key = "groups:$UserObjectId"
             if ($this.Store.ContainsKey($key)) {
@@ -206,7 +243,7 @@ Describe 'EntraID identity provider - Contract tests' {
             return $false
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name BatchMembershipChanges -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name BatchMembershipChanges -Value {
             param($Operations, $AccessToken)
             $results = @()
             foreach ($op in $Operations) {
@@ -226,16 +263,16 @@ Describe 'EntraID identity provider - Contract tests' {
             return $results
         }
 
-        $script:FakeAdapter = $fakeAdapter
+        $script:MockAdapter = $mockAdapter
     }
 
     Context 'Contracts' {
         Invoke-IdleIdentityProviderContractTests -NewProvider {
-            New-IdleEntraIDIdentityProvider -Adapter $script:FakeAdapter
+            New-IdleEntraIDIdentityProvider -Adapter $script:MockAdapter
         }
 
         Invoke-IdleProviderCapabilitiesContractTests -ProviderFactory {
-            New-IdleEntraIDIdentityProvider -Adapter $script:FakeAdapter
+            New-IdleEntraIDIdentityProvider -Adapter $script:MockAdapter
         }
 
         # Note: Generic entitlement contract tests are skipped for EntraID provider because:
@@ -284,26 +321,26 @@ Describe 'EntraID identity provider - Capabilities' {
 Describe 'EntraID identity provider - AllowDelete gate' {
     Context 'Guard' {
         It 'Throws when Delete is called without AllowDelete' {
-            $fakeAdapter = [pscustomobject]@{ PSTypeName = 'Fake' }
-            $provider = New-IdleEntraIDIdentityProvider -Adapter $fakeAdapter
+            $mockAdapter = [pscustomobject]@{ PSTypeName = 'Mock' }
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $mockAdapter
 
-            { $provider.DeleteIdentity('test-id', 'fake-token') } | Should -Throw '*Delete capability is not enabled*'
+            { $provider.DeleteIdentity('test-id', 'mock-token') } | Should -Throw '*Delete capability is not enabled*'
         }
 
         It 'Allows Delete when AllowDelete is true' {
-            $fakeAdapter = [pscustomobject]@{
-                PSTypeName = 'Fake'
+            $mockAdapter = [pscustomobject]@{
+                PSTypeName = 'Mock'
             }
-            $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+            $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
                 param($ObjectId, $AccessToken)
                 return $null
             }
 
-            $provider = New-IdleEntraIDIdentityProvider -AllowDelete -Adapter $fakeAdapter
+            $provider = New-IdleEntraIDIdentityProvider -AllowDelete -Adapter $mockAdapter
 
             # Use GUID format, should not throw capability error
             $userId = [guid]::NewGuid().ToString()
-            $result = $provider.DeleteIdentity($userId, 'fake-token')
+            $result = $provider.DeleteIdentity($userId, 'mock-token')
             $result.Changed | Should -BeFalse
         }
     }
@@ -312,12 +349,12 @@ Describe 'EntraID identity provider - AllowDelete gate' {
 Describe 'EntraID identity provider - Idempotency' {
     BeforeEach {
         $store = @{}
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
             Store      = $store
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             if ($this.Store.ContainsKey($ObjectId)) {
                 return $this.Store[$ObjectId]
@@ -325,7 +362,7 @@ Describe 'EntraID identity provider - Idempotency' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
             param($Upn, $AccessToken)
             foreach ($key in $this.Store.Keys) {
                 if ($this.Store[$key].userPrincipalName -eq $Upn) {
@@ -335,7 +372,7 @@ Describe 'EntraID identity provider - Idempotency' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
             param($Mail, $AccessToken)
             foreach ($key in $this.Store.Keys) {
                 if ($this.Store[$key].mail -eq $Mail) {
@@ -345,7 +382,7 @@ Describe 'EntraID identity provider - Idempotency' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
             param($Payload, $AccessToken)
             $id = [guid]::NewGuid().ToString()
             $user = @{
@@ -358,7 +395,7 @@ Describe 'EntraID identity provider - Idempotency' {
             return $user
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name PatchUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name PatchUser -Value {
             param($ObjectId, $Payload, $AccessToken)
             if ($this.Store.ContainsKey($ObjectId)) {
                 foreach ($prop in $Payload.Keys) {
@@ -367,14 +404,14 @@ Describe 'EntraID identity provider - Idempotency' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name DeleteUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name DeleteUser -Value {
             param($ObjectId, $AccessToken)
             if ($this.Store.ContainsKey($ObjectId)) {
                 $this.Store.Remove($ObjectId)
             }
         }
 
-        $script:TestAdapter = $fakeAdapter
+        $script:TestAdapter = $mockAdapter
     }
 
     Context 'Idempotency' {
@@ -386,13 +423,13 @@ Describe 'EntraID identity provider - Idempotency' {
                 DisplayName       = 'Test User'
             }
 
-            $result1 = $provider.CreateIdentity('test@test.local', $attrs, 'fake-token')
+            $result1 = $provider.CreateIdentity('test@test.local', $attrs, 'mock-token')
             $result1.Changed | Should -BeTrue
 
             $userId = $result1.IdentityKey
 
             # Second create should be idempotent
-            $result2 = $provider.CreateIdentity($userId, $attrs, 'fake-token')
+            $result2 = $provider.CreateIdentity($userId, $attrs, 'mock-token')
             $result2.Changed | Should -BeFalse
         }
 
@@ -400,7 +437,7 @@ Describe 'EntraID identity provider - Idempotency' {
             $provider = New-IdleEntraIDIdentityProvider -AllowDelete -Adapter $script:TestAdapter
 
             $userId = [guid]::NewGuid().ToString()
-            $result = $provider.DeleteIdentity($userId, 'fake-token')
+            $result = $provider.DeleteIdentity($userId, 'mock-token')
             $result.Changed | Should -BeFalse
         }
 
@@ -413,10 +450,10 @@ Describe 'EntraID identity provider - Idempotency' {
                 accountEnabled = $true
             }
 
-            $result1 = $provider.DisableIdentity($userId, 'fake-token')
+            $result1 = $provider.DisableIdentity($userId, 'mock-token')
             $result1.Changed | Should -BeTrue
 
-            $result2 = $provider.DisableIdentity($userId, 'fake-token')
+            $result2 = $provider.DisableIdentity($userId, 'mock-token')
             $result2.Changed | Should -BeFalse
         }
 
@@ -429,10 +466,10 @@ Describe 'EntraID identity provider - Idempotency' {
                 accountEnabled = $false
             }
 
-            $result1 = $provider.EnableIdentity($userId, 'fake-token')
+            $result1 = $provider.EnableIdentity($userId, 'mock-token')
             $result1.Changed | Should -BeTrue
 
-            $result2 = $provider.EnableIdentity($userId, 'fake-token')
+            $result2 = $provider.EnableIdentity($userId, 'mock-token')
             $result2.Changed | Should -BeFalse
         }
 
@@ -445,10 +482,10 @@ Describe 'EntraID identity provider - Idempotency' {
                 displayName = 'Old Name'
             }
 
-            $result1 = $provider.EnsureAttribute($userId, 'DisplayName', 'New Name', 'fake-token')
+            $result1 = $provider.EnsureAttribute($userId, 'DisplayName', 'New Name', 'mock-token')
             $result1.Changed | Should -BeTrue
 
-            $result2 = $provider.EnsureAttribute($userId, 'DisplayName', 'New Name', 'fake-token')
+            $result2 = $provider.EnsureAttribute($userId, 'DisplayName', 'New Name', 'mock-token')
             $result2.Changed | Should -BeFalse
         }
     }
@@ -456,12 +493,12 @@ Describe 'EntraID identity provider - Idempotency' {
 
 Describe 'EntraID identity provider - AuthSession handling' {
     BeforeEach {
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName    = 'IdLE.EntraIDAdapter.Fake'
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName    = 'IdLE.EntraIDAdapter.Mock'
             LastTokenUsed = $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             $this.LastTokenUsed = $AccessToken
             return @{
@@ -471,7 +508,7 @@ Describe 'EntraID identity provider - AuthSession handling' {
             }
         }
 
-        $script:TestAdapter = $fakeAdapter
+        $script:TestAdapter = $mockAdapter
     }
 
     Context 'AuthSession formats' {
@@ -531,12 +568,12 @@ Describe 'EntraID identity provider - AuthSession handling' {
 Describe 'EntraID identity provider - Identity resolution' {
     BeforeEach {
         $store = @{}
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
             Store      = $store
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             if ($this.Store.ContainsKey("id:$ObjectId")) {
                 return $this.Store["id:$ObjectId"]
@@ -544,7 +581,7 @@ Describe 'EntraID identity provider - Identity resolution' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
             param($Upn, $AccessToken)
             if ($this.Store.ContainsKey("upn:$Upn")) {
                 return $this.Store["upn:$Upn"]
@@ -552,7 +589,7 @@ Describe 'EntraID identity provider - Identity resolution' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
             param($Mail, $AccessToken)
             if ($this.Store.ContainsKey("mail:$Mail")) {
                 return $this.Store["mail:$Mail"]
@@ -560,7 +597,7 @@ Describe 'EntraID identity provider - Identity resolution' {
             return $null
         }
 
-        $script:TestAdapter = $fakeAdapter
+        $script:TestAdapter = $mockAdapter
     }
 
     Context 'Lookups' {
@@ -574,7 +611,7 @@ Describe 'EntraID identity provider - Identity resolution' {
                 displayName    = "User $guid"
             }
 
-            $result = $provider.GetIdentity($guid, 'fake-token')
+            $result = $provider.GetIdentity($guid, 'mock-token')
             $result.IdentityKey | Should -Be $guid
         }
 
@@ -590,7 +627,7 @@ Describe 'EntraID identity provider - Identity resolution' {
                 displayName       = "Test User"
             }
 
-            $result = $provider.GetIdentity($upn, 'fake-token')
+            $result = $provider.GetIdentity($upn, 'mock-token')
             $result.IdentityKey | Should -Be $upn  # Returns original key format
         }
 
@@ -606,25 +643,25 @@ Describe 'EntraID identity provider - Identity resolution' {
                 displayName    = "Test User"
             }
 
-            $result = $provider.GetIdentity($mail, 'fake-token')
+            $result = $provider.GetIdentity($mail, 'mock-token')
             $result.IdentityKey | Should -Be $mail  # Returns original key format
         }
 
         It 'Throws when identity is not found' {
             $provider = New-IdleEntraIDIdentityProvider -Adapter $script:TestAdapter
 
-            { $provider.GetIdentity('nonexistent@test.local', 'fake-token') } | Should -Throw '*not found*'
+            { $provider.GetIdentity('nonexistent@test.local', 'mock-token') } | Should -Throw '*not found*'
         }
     }
 }
 
 Describe 'EntraID identity provider - Group resolution' {
     BeforeEach {
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
             param($GroupId, $AccessToken)
             $guid = [System.Guid]::Empty
             if ([System.Guid]::TryParse($GroupId, [ref]$guid)) {
@@ -636,7 +673,7 @@ Describe 'EntraID identity provider - Group resolution' {
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
             param($DisplayName, $AccessToken)
             if ($DisplayName -eq 'AmbiguousGroup') {
                 throw "Multiple groups found with displayName '$DisplayName'. Use objectId for deterministic lookup."
@@ -647,7 +684,7 @@ Describe 'EntraID identity provider - Group resolution' {
             }
         }
 
-        $script:TestAdapter = $fakeAdapter
+        $script:TestAdapter = $mockAdapter
     }
 
     Context 'Lookups' {
@@ -655,7 +692,7 @@ Describe 'EntraID identity provider - Group resolution' {
             $provider = New-IdleEntraIDIdentityProvider -Adapter $script:TestAdapter
 
             $groupGuid = [guid]::NewGuid().ToString()
-            $resolvedId = $provider.ResolveGroup($groupGuid, 'fake-token')
+            $resolvedId = $provider.ResolveGroup($groupGuid, 'mock-token')
 
             $resolvedId | Should -Be $groupGuid
         }
@@ -663,25 +700,25 @@ Describe 'EntraID identity provider - Group resolution' {
         It 'Resolves group by displayName' {
             $provider = New-IdleEntraIDIdentityProvider -Adapter $script:TestAdapter
 
-            $resolvedId = $provider.ResolveGroup('UniqueGroup', 'fake-token')
+            $resolvedId = $provider.ResolveGroup('UniqueGroup', 'mock-token')
             $resolvedId | Should -Be 'resolved-UniqueGroup'
         }
 
         It 'Throws when multiple groups match displayName' {
             $provider = New-IdleEntraIDIdentityProvider -Adapter $script:TestAdapter
 
-            { $provider.ResolveGroup('AmbiguousGroup', 'fake-token') } | Should -Throw '*Multiple groups found*'
+            { $provider.ResolveGroup('AmbiguousGroup', 'mock-token') } | Should -Throw '*Multiple groups found*'
         }
     }
 }
 
 Describe 'EntraID identity provider - Entitlement operations' {
     BeforeAll {
-        function New-FakeEntraIDAdapterForEntitlements {
+        function New-MockEntraIDAdapterForEntitlements {
             $store = @{}
 
             $adapter = [pscustomobject]@{
-                PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+                PSTypeName = 'IdLE.EntraIDAdapter.Mock'
                 Store      = $store
             }
 
@@ -715,6 +752,43 @@ Describe 'EntraID identity provider - Entitlement operations' {
                     $this.Store[$key] = @()
                 }
                 return $this.Store[$key]
+            }
+
+            $adapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+                param($AuId, $AccessToken)
+                return @{ id = $AuId; displayName = "AU $AuId" }
+            }
+
+            $adapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
+                param($ObjectId, $AccessToken)
+                $key = "aus:$ObjectId"
+                if (-not $this.Store.ContainsKey($key)) {
+                    $this.Store[$key] = @()
+                }
+                return $this.Store[$key]
+            }
+
+            $adapter | Add-Member -MemberType ScriptMethod -Name AddAdministrativeUnitMember -Value {
+                param($AuObjectId, $UserObjectId, $AccessToken)
+                $key = "aus:$UserObjectId"
+                if (-not $this.Store.ContainsKey($key)) { $this.Store[$key] = @() }
+                $alreadyMember = $null -ne ($this.Store[$key] | Where-Object { $_.id -eq $AuObjectId })
+                if (-not $alreadyMember) {
+                    $this.Store[$key] += @{ id = $AuObjectId; displayName = "AU $AuObjectId" }
+                    return $true
+                }
+                return $false
+            }
+
+            $adapter | Add-Member -MemberType ScriptMethod -Name RemoveAdministrativeUnitMember -Value {
+                param($AuObjectId, $UserObjectId, $AccessToken)
+                $key = "aus:$UserObjectId"
+                if ($this.Store.ContainsKey($key)) {
+                    $wasMember = $null -ne ($this.Store[$key] | Where-Object { $_.id -eq $AuObjectId })
+                    $this.Store[$key] = @($this.Store[$key] | Where-Object { $_.id -ne $AuObjectId })
+                    return $wasMember
+                }
+                return $false
             }
 
             $adapter | Add-Member -MemberType ScriptMethod -Name AddGroupMember -Value {
@@ -778,7 +852,7 @@ Describe 'EntraID identity provider - Entitlement operations' {
             return $adapter
         }
 
-        $script:EntAdapter = New-FakeEntraIDAdapterForEntitlements
+        $script:EntAdapter = New-MockEntraIDAdapterForEntitlements
         $script:EntProvider = New-IdleEntraIDIdentityProvider -Adapter $script:EntAdapter
     }
 
@@ -936,19 +1010,106 @@ Describe 'EntraID identity provider - Entitlement operations' {
             $results[0].Changed | Should -Be $false
             $results[0].Error | Should -BeNullOrEmpty
         }
+
+        It 'GrantEntitlement returns stable result shape with Kind=AdministrativeUnit' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            $result = $script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $result.Operation | Should -Be 'GrantEntitlement'
+            $result.Changed | Should -Be $true
+            $result.Entitlement.Kind | Should -Be 'AdministrativeUnit'
+            $result.Entitlement.Id | Should -Be $auId
+        }
+
+        It 'GrantEntitlement is idempotent with Kind=AdministrativeUnit' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            $result1 = $script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+            $result2 = $script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $result1.Changed | Should -Be $true
+            $result2.Changed | Should -Be $false
+        }
+
+        It 'RevokeEntitlement is idempotent with Kind=AdministrativeUnit' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $result1 = $script:EntProvider.RevokeEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+            $result2 = $script:EntProvider.RevokeEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $result1.Changed | Should -Be $true
+            $result2.Changed | Should -Be $false
+        }
+
+        It 'ListEntitlements reflects AdministrativeUnit grant and revoke' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $auId = [guid]::NewGuid().ToString()
+
+            $before = @($script:EntProvider.ListEntitlements($userId))
+
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+            $afterGrant = @($script:EntProvider.ListEntitlements($userId))
+
+            [void]$script:EntProvider.RevokeEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+            $afterRevoke = @($script:EntProvider.ListEntitlements($userId))
+
+            @($afterGrant | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 1
+            @($afterRevoke | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 0
+        }
+
+        It 'ListEntitlements returns both Group and AdministrativeUnit entitlements' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $groupId = [guid]::NewGuid().ToString()
+            $auId = [guid]::NewGuid().ToString()
+
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'Group'; Id = $groupId })
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $entitlements = @($script:EntProvider.ListEntitlements($userId))
+
+            @($entitlements | Where-Object { $_.Kind -eq 'Group' -and $_.Id -eq $groupId }).Count | Should -Be 1
+            @($entitlements | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 1
+        }
+
+        It 'GrantEntitlement throws for unsupported Kind' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+
+            { $script:EntProvider.GrantEntitlement($userId, @{ Kind = 'Unknown'; Id = [guid]::NewGuid().ToString() }) } |
+                Should -Throw "*Kind 'Group' or 'AdministrativeUnit'*"
+        }
+
+        It 'RevokeEntitlement throws for unsupported Kind' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+
+            { $script:EntProvider.RevokeEntitlement($userId, @{ Kind = 'Unknown'; Id = [guid]::NewGuid().ToString() }) } |
+                Should -Throw "*Kind 'Group' or 'AdministrativeUnit'*"
+        }
     }
 }
 
 Describe 'EntraID identity provider - RevokeSessions' {
     BeforeAll {
-        # Create a fake adapter that tracks revocation calls
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName          = 'IdLE.EntraIDAdapter.Fake'
+        # Create a mock adapter that tracks revocation calls
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName          = 'IdLE.EntraIDAdapter.Mock'
             RevocationCallLog   = @()
             RevocationResponses = @{}
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             return @{
                 id                = $ObjectId
@@ -957,7 +1118,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
             param($Upn, $AccessToken)
             return @{
                 id                = 'test-user-id'
@@ -966,7 +1127,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
             param($Mail, $AccessToken)
             return @{
                 id                = 'test-user-id'
@@ -976,7 +1137,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             }
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name RevokeSignInSessions -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name RevokeSignInSessions -Value {
             param($ObjectId, $AccessToken)
             $this.RevocationCallLog += @{
                 ObjectId    = $ObjectId
@@ -993,7 +1154,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             }
         }
 
-        $script:RevokeAdapter = $fakeAdapter
+        $script:RevokeAdapter = $mockAdapter
         $script:RevokeProvider = New-IdleEntraIDIdentityProvider -Adapter $script:RevokeAdapter
     }
 
@@ -1011,7 +1172,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             $userId = [guid]::NewGuid().ToString()
             $script:RevokeAdapter.RevocationCallLog = @()
             
-            $result = $script:RevokeProvider.RevokeSessions($userId, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($userId, 'mock-token')
             
             $script:RevokeAdapter.RevocationCallLog.Count | Should -Be 1
             $script:RevokeAdapter.RevocationCallLog[0].ObjectId | Should -Be $userId
@@ -1020,7 +1181,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
         It 'RevokeSessions returns ProviderResult with correct shape' {
             $userId = [guid]::NewGuid().ToString()
             
-            $result = $script:RevokeProvider.RevokeSessions($userId, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($userId, 'mock-token')
             
             $result | Should -Not -BeNullOrEmpty
             $result.PSObject.TypeNames[0] | Should -Be 'IdLE.ProviderResult'
@@ -1035,7 +1196,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
                 value = $true
             }
             
-            $result = $script:RevokeProvider.RevokeSessions($userId, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($userId, 'mock-token')
             
             $result.Changed | Should -Be $true
         }
@@ -1046,7 +1207,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
                 value = $false
             }
             
-            $result = $script:RevokeProvider.RevokeSessions($userId, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($userId, 'mock-token')
             
             $result.Changed | Should -Be $false
         }
@@ -1055,7 +1216,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             $upn = 'test.user@contoso.com'
             $script:RevokeAdapter.RevocationCallLog = @()
             
-            $result = $script:RevokeProvider.RevokeSessions($upn, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($upn, 'mock-token')
             
             $script:RevokeAdapter.RevocationCallLog.Count | Should -Be 1
             $script:RevokeAdapter.RevocationCallLog[0].ObjectId | Should -Be 'test-user-id'
@@ -1065,7 +1226,7 @@ Describe 'EntraID identity provider - RevokeSessions' {
             $mail = 'test.user@contoso.com'
             $script:RevokeAdapter.RevocationCallLog = @()
             
-            $result = $script:RevokeProvider.RevokeSessions($mail, 'fake-token')
+            $result = $script:RevokeProvider.RevokeSessions($mail, 'mock-token')
             
             $script:RevokeAdapter.RevocationCallLog.Count | Should -Be 1
             $script:RevokeAdapter.RevocationCallLog[0].ObjectId | Should -Be 'test-user-id'
@@ -1087,29 +1248,29 @@ Describe 'EntraID identity provider - RevokeSessions' {
 
 Describe 'EntraID identity provider - Password generation' {
     BeforeAll {
-        # Create a fake adapter for password generation tests
-        $fakeAdapter = [pscustomobject]@{
-            PSTypeName = 'IdLE.EntraIDAdapter.Fake'
+        # Create a mock adapter for password generation tests
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
             Store      = @{}
             LastCreatePayload = $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserById -Value {
             param($ObjectId, $AccessToken)
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByUpn -Value {
             param($Upn, $AccessToken)
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetUserByMail -Value {
             param($Mail, $AccessToken)
             return $null
         }
 
-        $fakeAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name CreateUser -Value {
             param($Payload, $AccessToken)
             
             # Store the payload for inspection
@@ -1124,9 +1285,9 @@ Describe 'EntraID identity provider - Password generation' {
             }
         } -Force
 
-        $provider = New-IdleEntraIDIdentityProvider -Adapter $fakeAdapter
+        $provider = New-IdleEntraIDIdentityProvider -Adapter $mockAdapter
         $script:PasswordTestProvider = $provider
-        $script:PasswordTestAdapter = $fakeAdapter
+        $script:PasswordTestAdapter = $mockAdapter
     }
 
     Context 'Password generation' {
@@ -1136,7 +1297,7 @@ Describe 'EntraID identity provider - Password generation' {
                 DisplayName = 'New User'
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('newuser@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('newuser@contoso.com', $attrs, 'mock-token')
             
             # Verify password was generated
             $result.PasswordGenerated | Should -BeTrue
@@ -1150,7 +1311,7 @@ Describe 'EntraID identity provider - Password generation' {
                 DisplayName = 'User'
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user@contoso.com', $attrs, 'mock-token')
             
             # Verify plaintext password is not included
             $result.PSObject.Properties.Name | Should -Not -Contain 'GeneratedAccountPasswordPlainText'
@@ -1163,7 +1324,7 @@ Describe 'EntraID identity provider - Password generation' {
                 AllowPlainTextPasswordOutput = $true
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user2@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user2@contoso.com', $attrs, 'mock-token')
             
             # Verify plaintext password is included
             $result.GeneratedAccountPasswordPlainText | Should -Not -BeNullOrEmpty
@@ -1183,7 +1344,7 @@ Describe 'EntraID identity provider - Password generation' {
                 }
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user3@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user3@contoso.com', $attrs, 'mock-token')
             
             # Verify password was not generated (explicit password provided)
             $result.PSObject.Properties.Name | Should -Not -Contain 'PasswordGenerated'
@@ -1195,7 +1356,7 @@ Describe 'EntraID identity provider - Password generation' {
                 DisplayName = 'User 4'
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user4@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user4@contoso.com', $attrs, 'mock-token')
             
             # Verify the payload sent to adapter
             $script:PasswordTestAdapter.LastCreatePayload.passwordProfile.forceChangePasswordNextSignIn | Should -BeTrue
@@ -1208,7 +1369,7 @@ Describe 'EntraID identity provider - Password generation' {
                 ForceChangePasswordNextSignIn = $false
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('serviceaccount@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('serviceaccount@contoso.com', $attrs, 'mock-token')
             
             # Verify the payload sent to adapter
             $script:PasswordTestAdapter.LastCreatePayload.passwordProfile.forceChangePasswordNextSignIn | Should -BeFalse
@@ -1220,7 +1381,7 @@ Describe 'EntraID identity provider - Password generation' {
                 DisplayName = 'User 5'
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user5@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user5@contoso.com', $attrs, 'mock-token')
             
             # Verify ProtectedString can be converted back to SecureString
             $protectedString = $result.GeneratedAccountPasswordProtected
@@ -1238,7 +1399,7 @@ Describe 'EntraID identity provider - Password generation' {
                 AllowPlainTextPasswordOutput = $true
             }
 
-            $result = $script:PasswordTestProvider.CreateIdentity('user6@contoso.com', $attrs, 'fake-token')
+            $result = $script:PasswordTestProvider.CreateIdentity('user6@contoso.com', $attrs, 'mock-token')
             
             # Verify the generated password is a valid GUID
             $plainPwd = $result.GeneratedAccountPasswordPlainText
@@ -1262,37 +1423,37 @@ Describe 'EntraID identity provider - ResolveEntitlement' {
 
     Context 'ResolveEntitlement behavior' {
         BeforeAll {
-            # Fake adapter that returns canonical objectId for groups (mimics real Graph lookup)
-            $fakeAdapter = [pscustomobject]@{ PSTypeName = 'IdLE.EntraIDAdapter.Fake'; Store = @{} }
-            $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
+            # Mock adapter that returns canonical objectId for groups (mimics real Graph lookup)
+            $mockAdapter = [pscustomobject]@{ PSTypeName = 'IdLE.EntraIDAdapter.Mock'; Store = @{} }
+            $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
                 param($GroupId, $AccessToken)
                 return @{ id = $GroupId; displayName = "Group $GroupId" }
             }
-            $fakeAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
+            $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
                 param($DisplayName, $AccessToken)
                 return @{ id = "resolved-$DisplayName"; displayName = $DisplayName }
             }
-            $script:NormProvider = New-IdleEntraIDIdentityProvider -Adapter $fakeAdapter
+            $script:NormProvider = New-IdleEntraIDIdentityProvider -Adapter $mockAdapter
         }
 
         It 'Normalizes a Group entitlement with a GUID Id to canonical objectId' {
             $groupGuid = [guid]::NewGuid().ToString()
             $ent = @{ Kind = 'Group'; Id = $groupGuid }
-            $result = $script:NormProvider.ResolveEntitlement('Group', $ent, 'fake-token')
+            $result = $script:NormProvider.ResolveEntitlement('Group', $ent, 'mock-token')
             $result.Kind | Should -Be 'Group'
             $result.Id   | Should -Be $groupGuid
         }
 
         It 'Normalizes a Group entitlement with a displayName to canonical objectId' {
             $ent = @{ Kind = 'Group'; Id = 'HR Team' }
-            $result = $script:NormProvider.ResolveEntitlement('Group', $ent, 'fake-token')
+            $result = $script:NormProvider.ResolveEntitlement('Group', $ent, 'mock-token')
             $result.Kind | Should -Be 'Group'
             $result.Id   | Should -Be 'resolved-HR Team'
         }
 
         It 'Returns entitlement unchanged when Kind is not Group' {
             $ent = [pscustomobject]@{ Kind = 'License'; Id = 'Some-License-Id' }
-            $result = $script:NormProvider.ResolveEntitlement('License', $ent, 'fake-token')
+            $result = $script:NormProvider.ResolveEntitlement('License', $ent, 'mock-token')
             $result.Kind | Should -Be 'License'
             $result.Id   | Should -Be 'Some-License-Id'
         }
@@ -1345,7 +1506,7 @@ Describe 'EntraID adapter - GetAllPages paging regression' {
 
             $adapter = New-EntraIDPagingTestAdapter -PageSequence @($page)
             # Direct call; any thrown exception will fail this test automatically
-            $result = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'fake-token')
+            $result = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'mock-token')
             $result | Should -HaveCount 2
             $result[0].id | Should -Be 'g1'
             $result[1].id | Should -Be 'g2'
@@ -1364,7 +1525,7 @@ Describe 'EntraID adapter - GetAllPages paging regression' {
             }
 
             $adapter = New-EntraIDPagingTestAdapter -PageSequence @($page1, $page2)
-            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'fake-token')
+            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'mock-token')
             $result | Should -HaveCount 2
             ($result | Select-Object -ExpandProperty id) | Should -Contain 'g1'
             ($result | Select-Object -ExpandProperty id) | Should -Contain 'g2'
@@ -1382,7 +1543,7 @@ Describe 'EntraID adapter - GetAllPages paging regression' {
 
             $adapter = New-EntraIDPagingTestAdapter -PageSequence @($page)
             $result  = $null
-            { $result = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'fake-token') } | Should -Not -Throw
+            { $result = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'mock-token') } | Should -Not -Throw
             $result | Should -HaveCount 1
         }
 
@@ -1396,7 +1557,7 @@ Describe 'EntraID adapter - GetAllPages paging regression' {
             }
 
             $adapter = New-EntraIDPagingTestAdapter -PageSequence @($page1, $page2)
-            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'fake-token')
+            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/groups', 'mock-token')
             $result | Should -HaveCount 2
         }
     }
@@ -1406,7 +1567,7 @@ Describe 'EntraID adapter - GetAllPages paging regression' {
             $page = [pscustomobject]@{ id = 'single-object'; displayName = 'Something' }
 
             $adapter = New-EntraIDPagingTestAdapter -PageSequence @($page)
-            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/something', 'fake-token')
+            $result  = $adapter.GetAllPages('https://graph.microsoft.com/v1.0/something', 'mock-token')
             $result | Should -HaveCount 0
         }
     }

--- a/tests/Providers/EntraIDIdentityProvider.Tests.ps1
+++ b/tests/Providers/EntraIDIdentityProvider.Tests.ps1
@@ -173,6 +173,11 @@ Describe 'EntraID identity provider - Contract tests' {
             return @{ id = $AuId; displayName = "AU $AuId" }
         }
 
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitByDisplayName -Value {
+            param($DisplayName, $AccessToken)
+            return @{ id = "resolved-au-$DisplayName"; displayName = $DisplayName }
+        }
+
         $mockAdapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
             param($ObjectId, $AccessToken)
             $key = "aus:$ObjectId"
@@ -712,6 +717,79 @@ Describe 'EntraID identity provider - Group resolution' {
     }
 }
 
+Describe 'EntraID identity provider - Administrative Unit resolution' {
+    BeforeEach {
+        $mockAdapter = [pscustomobject]@{
+            PSTypeName = 'IdLE.EntraIDAdapter.Mock'
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+            param($AuId, $AccessToken)
+            $guid = [System.Guid]::Empty
+            if ([System.Guid]::TryParse($AuId, [ref]$guid)) {
+                return @{ id = $AuId; displayName = "AU $AuId" }
+            }
+            return $null
+        }
+
+        $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitByDisplayName -Value {
+            param($DisplayName, $AccessToken)
+            if ($DisplayName -eq 'AmbiguousAU') {
+                throw "Multiple Administrative Units found with displayName '$DisplayName'. Use objectId for deterministic lookup."
+            }
+            if ($DisplayName -eq 'MissingAU') {
+                return $null
+            }
+            return @{ id = "resolved-au-$DisplayName"; displayName = $DisplayName }
+        }
+
+        $script:AuTestAdapter = $mockAdapter
+    }
+
+    Context 'Lookups' {
+        It 'Resolves Administrative Unit by objectId' {
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $script:AuTestAdapter
+
+            $auGuid = [guid]::NewGuid().ToString()
+            $resolvedId = $provider.ResolveAdministrativeUnit($auGuid, 'mock-token')
+
+            $resolvedId | Should -Be $auGuid
+        }
+
+        It 'Resolves Administrative Unit by displayName' {
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $script:AuTestAdapter
+
+            $resolvedId = $provider.ResolveAdministrativeUnit('EU Region Admins', 'mock-token')
+            $resolvedId | Should -Be 'resolved-au-EU Region Admins'
+        }
+
+        It 'Throws when GUID objectId is not found' {
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $script:AuTestAdapter
+
+            $missingGuid = [guid]::NewGuid().ToString()
+            # Override GetAdministrativeUnitById to return null for this GUID
+            $script:AuTestAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+                param($AuId, $AccessToken)
+                return $null
+            } -Force
+
+            { $provider.ResolveAdministrativeUnit($missingGuid, 'mock-token') } | Should -Throw '*not found*'
+        }
+
+        It 'Throws when displayName is not found' {
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $script:AuTestAdapter
+
+            { $provider.ResolveAdministrativeUnit('MissingAU', 'mock-token') } | Should -Throw '*not found*'
+        }
+
+        It 'Throws when multiple Administrative Units match displayName' {
+            $provider = New-IdleEntraIDIdentityProvider -Adapter $script:AuTestAdapter
+
+            { $provider.ResolveAdministrativeUnit('AmbiguousAU', 'mock-token') } | Should -Throw '*Multiple Administrative Units found*'
+        }
+    }
+}
+
 Describe 'EntraID identity provider - Entitlement operations' {
     BeforeAll {
         function New-MockEntraIDAdapterForEntitlements {
@@ -757,6 +835,11 @@ Describe 'EntraID identity provider - Entitlement operations' {
             $adapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
                 param($AuId, $AccessToken)
                 return @{ id = $AuId; displayName = "AU $AuId" }
+            }
+
+            $adapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitByDisplayName -Value {
+                param($DisplayName, $AccessToken)
+                return @{ id = "resolved-au-$DisplayName"; displayName = $DisplayName }
             }
 
             $adapter | Add-Member -MemberType ScriptMethod -Name ListUserAdministrativeUnits -Value {
@@ -1423,7 +1506,7 @@ Describe 'EntraID identity provider - ResolveEntitlement' {
 
     Context 'ResolveEntitlement behavior' {
         BeforeAll {
-            # Mock adapter that returns canonical objectId for groups (mimics real Graph lookup)
+            # Mock adapter that returns canonical objectId for groups and AUs (mimics real Graph lookup)
             $mockAdapter = [pscustomobject]@{ PSTypeName = 'IdLE.EntraIDAdapter.Mock'; Store = @{} }
             $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupById -Value {
                 param($GroupId, $AccessToken)
@@ -1432,6 +1515,14 @@ Describe 'EntraID identity provider - ResolveEntitlement' {
             $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetGroupByDisplayName -Value {
                 param($DisplayName, $AccessToken)
                 return @{ id = "resolved-$DisplayName"; displayName = $DisplayName }
+            }
+            $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitById -Value {
+                param($AuId, $AccessToken)
+                return @{ id = $AuId; displayName = "AU $AuId" }
+            }
+            $mockAdapter | Add-Member -MemberType ScriptMethod -Name GetAdministrativeUnitByDisplayName -Value {
+                param($DisplayName, $AccessToken)
+                return @{ id = "resolved-au-$DisplayName"; displayName = $DisplayName }
             }
             $script:NormProvider = New-IdleEntraIDIdentityProvider -Adapter $mockAdapter
         }
@@ -1449,6 +1540,21 @@ Describe 'EntraID identity provider - ResolveEntitlement' {
             $result = $script:NormProvider.ResolveEntitlement('Group', $ent, 'mock-token')
             $result.Kind | Should -Be 'Group'
             $result.Id   | Should -Be 'resolved-HR Team'
+        }
+
+        It 'Normalizes an AdministrativeUnit entitlement with a GUID Id to canonical objectId' {
+            $auGuid = [guid]::NewGuid().ToString()
+            $ent = @{ Kind = 'AdministrativeUnit'; Id = $auGuid }
+            $result = $script:NormProvider.ResolveEntitlement('AdministrativeUnit', $ent, 'mock-token')
+            $result.Kind | Should -Be 'AdministrativeUnit'
+            $result.Id   | Should -Be $auGuid
+        }
+
+        It 'Normalizes an AdministrativeUnit entitlement with a displayName to canonical objectId' {
+            $ent = @{ Kind = 'AdministrativeUnit'; Id = 'EU Region Admins' }
+            $result = $script:NormProvider.ResolveEntitlement('AdministrativeUnit', $ent, 'mock-token')
+            $result.Kind | Should -Be 'AdministrativeUnit'
+            $result.Id   | Should -Be 'resolved-au-EU Region Admins'
         }
 
         It 'Returns entitlement unchanged when Kind is not Group' {

--- a/tests/Providers/EntraIDIdentityProvider.Tests.ps1
+++ b/tests/Providers/EntraIDIdentityProvider.Tests.ps1
@@ -1252,7 +1252,37 @@ Describe 'EntraID identity provider - Entitlement operations' {
             @($afterRevoke | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 0
         }
 
-        It 'ListEntitlements returns both Group and AdministrativeUnit entitlements' {
+        It 'ListEntitlements with Kind=Group only returns Group entitlements and does not call ListUserAdministrativeUnits' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $groupId = [guid]::NewGuid().ToString()
+            $auId    = [guid]::NewGuid().ToString()
+
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'Group'; Id = $groupId })
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $entitlements = @($script:EntProvider.ListEntitlements($userId, $null, 'Group'))
+
+            @($entitlements | Where-Object { $_.Kind -eq 'Group' -and $_.Id -eq $groupId }).Count | Should -Be 1
+            @($entitlements | Where-Object { $_.Kind -eq 'AdministrativeUnit' }).Count | Should -Be 0
+        }
+
+        It 'ListEntitlements with Kind=AdministrativeUnit only returns AU entitlements and does not call ListUserGroups' {
+            $userId = [guid]::NewGuid().ToString()
+            [void]$script:EntProvider.GetIdentity($userId)
+            $groupId = [guid]::NewGuid().ToString()
+            $auId    = [guid]::NewGuid().ToString()
+
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'Group'; Id = $groupId })
+            [void]$script:EntProvider.GrantEntitlement($userId, @{ Kind = 'AdministrativeUnit'; Id = $auId })
+
+            $entitlements = @($script:EntProvider.ListEntitlements($userId, $null, 'AdministrativeUnit'))
+
+            @($entitlements | Where-Object { $_.Kind -eq 'AdministrativeUnit' -and $_.Id -eq $auId }).Count | Should -Be 1
+            @($entitlements | Where-Object { $_.Kind -eq 'Group' }).Count | Should -Be 0
+        }
+
+        It 'ListEntitlements with no Kind returns both Group and AdministrativeUnit entitlements' {
             $userId = [guid]::NewGuid().ToString()
             [void]$script:EntProvider.GetIdentity($userId)
             $groupId = [guid]::NewGuid().ToString()


### PR DESCRIPTION
## Summary

Closes #287.

Extends the Entra ID provider (`IdLE.Provider.EntraID`) to manage **Administrative Unit (AU) memberships** via the existing entitlement contract, using `Kind = 'AdministrativeUnit'`. No Step or Core changes are required — the implementation is fully contained within the provider.

## What changed

### `New-IdleEntraIDAdapter.ps1`
- `ListUserGroups` now uses the type-cast endpoint `/memberOf/microsoft.graph.group` (was `/memberOf`) to ensure groups and AUs are never mixed in the same response.
- New methods: `GetAdministrativeUnitById`, `ListUserAdministrativeUnits`, `AddAdministrativeUnitMember`, `RemoveAdministrativeUnitMember`.

### `New-IdleEntraIDIdentityProvider.ps1`
- New `ResolveAdministrativeUnit` helper: validates AU exists by GUID and throws a clear, actionable error if not found. GUID-only (display-name lookup not supported for AUs).
- `ListEntitlements` now returns **both** `Kind = 'Group'` and `Kind = 'AdministrativeUnit'` entitlements.
- `GrantEntitlement` and `RevokeEntitlement` dispatch on `Kind` — both `Group` and `AdministrativeUnit` are supported; any other Kind throws immediately with a descriptive error.
- `ResolveEntitlement` extended to canonicalise `Kind = 'AdministrativeUnit'` entitlements.
- `PruneEntitlements` works automatically (step-level composition of List + Revoke; no provider changes needed).

### `docs/reference/providers/provider-entraID.md`
- `IdLE.Entitlement.List` capability table extended with `Kind = 'AdministrativeUnit'` shape.
- New **Administrative Unit entitlements** section with: operations table, workflow examples (Present + Absent), constraints (GUID-only, no bulk support), Graph endpoints table.
- Required permissions table added (`AdministrativeUnit.Read.All`, `AdministrativeUnit.ReadWrite.All`).
- Troubleshooting entry for AU not found.

### `tests/Providers/EntraIDIdentityProvider.Tests.ps1`
- Both mock adapters extended with all four new AU adapter methods.
- 8 new tests: `GrantEntitlement`/`RevokeEntitlement` result shape, idempotency, `ListEntitlements` reflects AU grant/revoke, combined Group+AU listing, unsupported Kind throws.
- Renamed all `Fake`/`fake` identifiers to `Mock`/`mock` throughout the file (variable names, type names, function names).

## Reviewer notes

- `BulkGrantEntitlements` / `BulkRevokeEntitlements` remain **Group-only** — the Graph batch API uses group-specific URLs and AU bulk operations were not requested in the issue. This is documented explicitly.
- AU IDs are GUID-only by design: AU display names are not tenant-unique, making name-based lookup unsafe.
- The `ListUserGroups` type-cast tightening is a correctness fix: the old `/memberOf` endpoint returned all directory object types (including AUs, directory roles), which were all incorrectly labelled `Kind = 'Group'`.

## Test results

864 tests passed, 0 failed, 0 skipped.